### PR TITLE
chore(deps): update to core-js@3.4.1

### DIFF
--- a/auto.js
+++ b/auto.js
@@ -1,4 +1,4 @@
-require("core-js/shim");
+require("core-js/stable");
 var fakeIndexedDB = require("./build/fakeIndexedDB").default;
 var FDBCursor = require("./build/FDBCursor").default;
 var FDBCursorWithValue = require("./build/FDBCursorWithValue").default;
@@ -17,10 +17,10 @@ var globalVar =
     typeof window !== "undefined"
         ? window
         : typeof WorkerGlobalScope !== "undefined"
-            ? self
-            : typeof global !== "undefined"
-                ? global
-                : Function("return this;")();
+        ? self
+        : typeof global !== "undefined"
+        ? global
+        : Function("return this;")();
 
 globalVar.indexedDB = fakeIndexedDB;
 globalVar.IDBCursor = FDBCursor;

--- a/lib/FDBCursor.js
+++ b/lib/FDBCursor.js
@@ -2,5 +2,5 @@
 // <https://github.com/Microsoft/TypeScript/issues/2719> and <http://stackoverflow.com/q/30302747/786644>. It should not
 // be used internally, only externally.
 
-require("core-js/shim");
+require("core-js/stable");
 module.exports = require("../build/FDBCursor").default;

--- a/lib/FDBCursorWithValue.js
+++ b/lib/FDBCursorWithValue.js
@@ -2,5 +2,5 @@
 // <https://github.com/Microsoft/TypeScript/issues/2719> and <http://stackoverflow.com/q/30302747/786644>. It should not
 // be used internally, only externally.
 
-require("core-js/shim");
+require("core-js/stable");
 module.exports = require("../build/FDBCursorWithValue").default;

--- a/lib/FDBDatabase.js
+++ b/lib/FDBDatabase.js
@@ -2,5 +2,5 @@
 // <https://github.com/Microsoft/TypeScript/issues/2719> and <http://stackoverflow.com/q/30302747/786644>. It should not
 // be used internally, only externally.
 
-require("core-js/shim");
+require("core-js/stable");
 module.exports = require("../build/FDBDatabase").default;

--- a/lib/FDBFactory.js
+++ b/lib/FDBFactory.js
@@ -2,5 +2,5 @@
 // <https://github.com/Microsoft/TypeScript/issues/2719> and <http://stackoverflow.com/q/30302747/786644>. It should not
 // be used internally, only externally.
 
-require("core-js/shim");
+require("core-js/stable");
 module.exports = require("../build/FDBFactory").default;

--- a/lib/FDBIndex.js
+++ b/lib/FDBIndex.js
@@ -2,5 +2,5 @@
 // <https://github.com/Microsoft/TypeScript/issues/2719> and <http://stackoverflow.com/q/30302747/786644>. It should not
 // be used internally, only externally.
 
-require("core-js/shim");
+require("core-js/stable");
 module.exports = require("../build/FDBIndex").default;

--- a/lib/FDBKeyRange.js
+++ b/lib/FDBKeyRange.js
@@ -2,5 +2,5 @@
 // <https://github.com/Microsoft/TypeScript/issues/2719> and <http://stackoverflow.com/q/30302747/786644>. It should not
 // be used internally, only externally.
 
-require("core-js/shim");
+require("core-js/stable");
 module.exports = require("../build/FDBKeyRange").default;

--- a/lib/FDBObjectStore.js
+++ b/lib/FDBObjectStore.js
@@ -2,5 +2,5 @@
 // <https://github.com/Microsoft/TypeScript/issues/2719> and <http://stackoverflow.com/q/30302747/786644>. It should not
 // be used internally, only externally.
 
-require("core-js/shim");
+require("core-js/stable");
 module.exports = require("../build/FDBObjectStore").default;

--- a/lib/FDBOpenDBRequest.js
+++ b/lib/FDBOpenDBRequest.js
@@ -2,5 +2,5 @@
 // <https://github.com/Microsoft/TypeScript/issues/2719> and <http://stackoverflow.com/q/30302747/786644>. It should not
 // be used internally, only externally.
 
-require("core-js/shim");
+require("core-js/stable");
 module.exports = require("../build/FDBOpenDBRequest").default;

--- a/lib/FDBRequest.js
+++ b/lib/FDBRequest.js
@@ -2,5 +2,5 @@
 // <https://github.com/Microsoft/TypeScript/issues/2719> and <http://stackoverflow.com/q/30302747/786644>. It should not
 // be used internally, only externally.
 
-require("core-js/shim");
+require("core-js/stable");
 module.exports = require("../build/FDBRequest").default;

--- a/lib/FDBTransaction.js
+++ b/lib/FDBTransaction.js
@@ -2,5 +2,5 @@
 // <https://github.com/Microsoft/TypeScript/issues/2719> and <http://stackoverflow.com/q/30302747/786644>. It should not
 // be used internally, only externally.
 
-require("core-js/shim");
+require("core-js/stable");
 module.exports = require("../build/FDBTransaction").default;

--- a/lib/FDBVersionChangeEvent.js
+++ b/lib/FDBVersionChangeEvent.js
@@ -2,5 +2,5 @@
 // <https://github.com/Microsoft/TypeScript/issues/2719> and <http://stackoverflow.com/q/30302747/786644>. It should not
 // be used internally, only externally.
 
-require("core-js/shim");
+require("core-js/stable");
 module.exports = require("../build/FDBVersionChangeEvent").default;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "lib"
     ],
     "dependencies": {
-        "core-js": "^2.4.1",
+        "core-js": "^3.4.1",
         "realistic-structured-clone": "^2.0.1",
         "setimmediate": "^1.0.5"
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import "core-js/shim";
+import "core-js/stable";
 import fakeIndexedDB from "./fakeIndexedDB";
 
 module.exports = fakeIndexedDB;


### PR DESCRIPTION
`core-js` v3 has been released. Here is a handy upgrade guide: https://babeljs.io/blog/2019/03/19/7.4.0#migration-from-core-js-2