### PR TITLE
use DOMException

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "lib"
     ],
     "dependencies": {
+        "domexception": "^2.0.1",
         "realistic-structured-clone": "^2.0.1",
         "setimmediate": "^1.0.5"
     },

--- a/src/FDBCursor.ts
+++ b/src/FDBCursor.ts
@@ -3,11 +3,11 @@ import FDBObjectStore from "./FDBObjectStore";
 import FDBRequest from "./FDBRequest";
 import cmp from "./lib/cmp";
 import {
-    DataError,
-    InvalidAccessError,
-    InvalidStateError,
-    ReadOnlyError,
-    TransactionInactiveError,
+    newDataError,
+    newInvalidAccessError,
+    newInvalidStateError,
+    newReadOnlyError,
+    newTransactionInactiveError,
 } from "./lib/errors";
 import extractKey from "./lib/extractKey";
 import structuredClone from "./lib/structuredClone";
@@ -352,25 +352,25 @@ class FDBCursor {
         const transaction = effectiveObjectStore.transaction;
 
         if (transaction._state !== "active") {
-            throw new TransactionInactiveError();
+            throw newTransactionInactiveError();
         }
 
         if (transaction.mode === "readonly") {
-            throw new ReadOnlyError();
+            throw newReadOnlyError();
         }
 
         if (effectiveObjectStore._rawObjectStore.deleted) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
         if (
             !(this.source instanceof FDBObjectStore) &&
             this.source._rawIndex.deleted
         ) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         if (!this._gotValue || !this.hasOwnProperty("value")) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         const clone = structuredClone(value);
@@ -385,7 +385,7 @@ class FDBCursor {
             }
 
             if (cmp(tempKey, effectiveKey) !== 0) {
-                throw new DataError();
+                throw newDataError();
             }
         }
 
@@ -415,21 +415,21 @@ class FDBCursor {
         const transaction = effectiveObjectStore.transaction;
 
         if (transaction._state !== "active") {
-            throw new TransactionInactiveError();
+            throw newTransactionInactiveError();
         }
 
         if (effectiveObjectStore._rawObjectStore.deleted) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
         if (
             !(this.source instanceof FDBObjectStore) &&
             this.source._rawIndex.deleted
         ) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         if (!this._gotValue) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         if (this._request) {
@@ -461,21 +461,21 @@ class FDBCursor {
         const transaction = effectiveObjectStore.transaction;
 
         if (transaction._state !== "active") {
-            throw new TransactionInactiveError();
+            throw newTransactionInactiveError();
         }
 
         if (effectiveObjectStore._rawObjectStore.deleted) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
         if (
             !(this.source instanceof FDBObjectStore) &&
             this.source._rawIndex.deleted
         ) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         if (!this._gotValue) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         if (key !== undefined) {
@@ -491,7 +491,7 @@ class FDBCursor {
                     (this.direction === "prev" ||
                         this.direction === "prevunique"))
             ) {
-                throw new DataError();
+                throw newDataError();
             }
         }
 
@@ -513,33 +513,33 @@ class FDBCursor {
         const transaction = effectiveObjectStore.transaction;
 
         if (transaction._state !== "active") {
-            throw new TransactionInactiveError();
+            throw newTransactionInactiveError();
         }
 
         if (effectiveObjectStore._rawObjectStore.deleted) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
         if (
             !(this.source instanceof FDBObjectStore) &&
             this.source._rawIndex.deleted
         ) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         if (
             this.source instanceof FDBObjectStore ||
             (this.direction !== "next" && this.direction !== "prev")
         ) {
-            throw new InvalidAccessError();
+            throw newInvalidAccessError();
         }
 
         if (!this._gotValue) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         // Not sure about this
         if (key === undefined || primaryKey === undefined) {
-            throw new DataError();
+            throw newDataError();
         }
 
         key = valueToKey(key);
@@ -548,7 +548,7 @@ class FDBCursor {
             (cmpResult === -1 && this.direction === "next") ||
             (cmpResult === 1 && this.direction === "prev")
         ) {
-            throw new DataError();
+            throw newDataError();
         }
         const cmpResult2 = cmp(primaryKey, this._objectStorePosition);
         if (cmpResult === 0) {
@@ -556,7 +556,7 @@ class FDBCursor {
                 (cmpResult2 <= 0 && this.direction === "next") ||
                 (cmpResult2 >= 0 && this.direction === "prev")
             ) {
-                throw new DataError();
+                throw newDataError();
             }
         }
 
@@ -580,25 +580,25 @@ class FDBCursor {
         const transaction = effectiveObjectStore.transaction;
 
         if (transaction._state !== "active") {
-            throw new TransactionInactiveError();
+            throw newTransactionInactiveError();
         }
 
         if (transaction.mode === "readonly") {
-            throw new ReadOnlyError();
+            throw newReadOnlyError();
         }
 
         if (effectiveObjectStore._rawObjectStore.deleted) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
         if (
             !(this.source instanceof FDBObjectStore) &&
             this.source._rawIndex.deleted
         ) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         if (!this._gotValue || !this.hasOwnProperty("value")) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         return transaction._execRequestAsync({

--- a/src/FDBDatabase.ts
+++ b/src/FDBDatabase.ts
@@ -1,11 +1,11 @@
 import FDBTransaction from "./FDBTransaction";
 import Database from "./lib/Database";
 import {
-    ConstraintError,
-    InvalidAccessError,
-    InvalidStateError,
-    NotFoundError,
-    TransactionInactiveError,
+    newConstraintError,
+    newInvalidAccessError,
+    newInvalidStateError,
+    newNotFoundError,
+    newTransactionInactiveError,
 } from "./lib/errors";
 import fakeDOMStringList from "./lib/fakeDOMStringList";
 import FakeEventTarget from "./lib/FakeEventTarget";
@@ -15,7 +15,7 @@ import validateKeyPath from "./lib/validateKeyPath";
 
 const confirmActiveVersionchangeTransaction = (database: FDBDatabase) => {
     if (!database._runningVersionchangeTransaction) {
-        throw new InvalidStateError();
+        throw newInvalidStateError();
     }
 
     // Find the latest versionchange transaction
@@ -25,11 +25,11 @@ const confirmActiveVersionchangeTransaction = (database: FDBDatabase) => {
     const transaction = transactions[transactions.length - 1];
 
     if (!transaction || transaction._state === "finished") {
-        throw new InvalidStateError();
+        throw newInvalidStateError();
     }
 
     if (transaction._state !== "active") {
-        throw new TransactionInactiveError();
+        throw newTransactionInactiveError();
     }
 
     return transaction;
@@ -107,11 +107,11 @@ class FDBDatabase extends FakeEventTarget {
         }
 
         if (this._rawDatabase.rawObjectStores.has(name)) {
-            throw new ConstraintError();
+            throw newConstraintError();
         }
 
         if (autoIncrement && (keyPath === "" || Array.isArray(keyPath))) {
-            throw new InvalidAccessError();
+            throw newInvalidAccessError();
         }
 
         const objectStoreNames = this.objectStoreNames.slice();
@@ -150,7 +150,7 @@ class FDBDatabase extends FakeEventTarget {
 
         const store = this._rawDatabase.rawObjectStores.get(name);
         if (store === undefined) {
-            throw new NotFoundError();
+            throw newNotFoundError();
         }
 
         this.objectStoreNames = fakeDOMStringList(
@@ -194,22 +194,22 @@ class FDBDatabase extends FakeEventTarget {
             },
         );
         if (hasActiveVersionchange) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         if (this._closePending) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         if (!Array.isArray(storeNames)) {
             storeNames = [storeNames];
         }
         if (storeNames.length === 0 && mode !== "versionchange") {
-            throw new InvalidAccessError();
+            throw newInvalidAccessError();
         }
         for (const storeName of storeNames) {
             if (this.objectStoreNames.indexOf(storeName) < 0) {
-                throw new NotFoundError(
+                throw newNotFoundError(
                     "No objectStore named " + storeName + " in this database",
                 );
             }

--- a/src/FDBFactory.ts
+++ b/src/FDBFactory.ts
@@ -5,7 +5,7 @@ import FDBVersionChangeEvent from "./FDBVersionChangeEvent";
 import cmp from "./lib/cmp";
 import Database from "./lib/Database";
 import enforceRange from "./lib/enforceRange";
-import { AbortError, VersionError } from "./lib/errors";
+import { newAbortError, newVersionError } from "./lib/errors";
 import FakeEvent from "./lib/FakeEvent";
 
 const waitForOthersClosedDelete = (
@@ -161,7 +161,7 @@ const runVersionchangeTransaction = (
             connection._runningVersionchangeTransaction = false;
             request.transaction = null;
             setImmediate(() => {
-                cb(new AbortError());
+                cb(newAbortError());
             });
         });
         transaction.addEventListener("complete", () => {
@@ -170,7 +170,7 @@ const runVersionchangeTransaction = (
             // Let other complete event handlers run before continuing
             setImmediate(() => {
                 if (connection._closePending) {
-                    cb(new AbortError());
+                    cb(newAbortError());
                 } else {
                     cb(null);
                 }
@@ -200,7 +200,7 @@ const openDatabase = (
     }
 
     if (db.version > version) {
-        return cb(new VersionError());
+        return cb(newVersionError());
     }
 
     const connection = new FDBDatabase(db);

--- a/src/FDBIndex.ts
+++ b/src/FDBIndex.ts
@@ -5,9 +5,9 @@ import FDBObjectStore from "./FDBObjectStore";
 import FDBRequest from "./FDBRequest";
 import enforceRange from "./lib/enforceRange";
 import {
-    ConstraintError,
-    InvalidStateError,
-    TransactionInactiveError,
+    newConstraintError,
+    newInvalidStateError,
+    newTransactionInactiveError,
 } from "./lib/errors";
 import fakeDOMStringList from "./lib/fakeDOMStringList";
 import Index from "./lib/Index";
@@ -17,11 +17,11 @@ import valueToKeyRange from "./lib/valueToKeyRange";
 
 const confirmActiveTransaction = (index: FDBIndex) => {
     if (index._rawIndex.deleted || index.objectStore._rawObjectStore.deleted) {
-        throw new InvalidStateError();
+        throw newInvalidStateError();
     }
 
     if (index.objectStore.transaction._state !== "active") {
-        throw new TransactionInactiveError();
+        throw newTransactionInactiveError();
     }
 };
 
@@ -54,18 +54,18 @@ class FDBIndex {
         const transaction = this.objectStore.transaction;
 
         if (!transaction.db._runningVersionchangeTransaction) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         if (transaction._state !== "active") {
-            throw new TransactionInactiveError();
+            throw newTransactionInactiveError();
         }
 
         if (
             this._rawIndex.deleted ||
             this.objectStore._rawObjectStore.deleted
         ) {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
 
         name = String(name);
@@ -75,7 +75,7 @@ class FDBIndex {
         }
 
         if (this.objectStore.indexNames.indexOf(name) >= 0) {
-            throw new ConstraintError();
+            throw newConstraintError();
         }
 
         const oldName = this._name;

--- a/src/FDBKeyRange.ts
+++ b/src/FDBKeyRange.ts
@@ -1,5 +1,5 @@
 import cmp from "./lib/cmp";
-import { DataError } from "./lib/errors";
+import { newDataError } from "./lib/errors";
 import { Key } from "./lib/types";
 import valueToKey from "./lib/valueToKey";
 
@@ -41,7 +41,7 @@ class FDBKeyRange {
 
         const cmpResult = cmp(lower, upper);
         if (cmpResult === 1 || (cmpResult === 0 && (lowerOpen || upperOpen))) {
-            throw new DataError();
+            throw newDataError();
         }
 
         lower = valueToKey(lower);

--- a/src/FDBRequest.ts
+++ b/src/FDBRequest.ts
@@ -2,7 +2,7 @@ import FDBCursor from "./FDBCursor";
 import FDBIndex from "./FDBIndex";
 import FDBObjectStore from "./FDBObjectStore";
 import FDBTransaction from "./FDBTransaction";
-import { InvalidStateError } from "./lib/errors";
+import { newInvalidStateError } from "./lib/errors";
 import FakeEventTarget from "./lib/FakeEventTarget";
 import { EventCallback } from "./lib/types";
 
@@ -17,7 +17,7 @@ class FDBRequest extends FakeEventTarget {
 
     public get error() {
         if (this.readyState === "pending") {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
         return this._error;
     }
@@ -28,7 +28,7 @@ class FDBRequest extends FakeEventTarget {
 
     public get result() {
         if (this.readyState === "pending") {
-            throw new InvalidStateError();
+            throw newInvalidStateError();
         }
         return this._result;
     }

--- a/src/FDBTransaction.ts
+++ b/src/FDBTransaction.ts
@@ -214,7 +214,7 @@ class FDBTransaction extends FakeEventTarget {
                     request.dispatchEvent(event);
                 } catch (err) {
                     if (this._state !== "committing") {
-                        this._abort("newAbortError");
+                        this._abort("AbortError");
                     }
                     throw err;
                 }

--- a/src/lib/FakeEventTarget.ts
+++ b/src/lib/FakeEventTarget.ts
@@ -1,4 +1,4 @@
-import { InvalidStateError } from "./errors";
+import { newInvalidStateError } from "./errors";
 import FakeEvent from "./FakeEvent";
 import { EventCallback, EventType } from "./types";
 
@@ -113,7 +113,7 @@ abstract class FakeEventTarget {
     // http://www.w3.org/TR/dom/#dispatching-events
     public dispatchEvent(event: FakeEvent) {
         if (event.dispatched || !event.initialized) {
-            throw new InvalidStateError("The object is in an invalid state.");
+            throw newInvalidStateError("The object is in an invalid state.");
         }
         event.isTrusted = false;
 

--- a/src/lib/Index.ts
+++ b/src/lib/Index.ts
@@ -92,7 +92,7 @@ class Index {
         try {
             indexKey = extractKey(this.keyPath, newRecord.value);
         } catch (err) {
-            if (err.name === "newDataError") {
+            if (err.name === "DataError") {
                 // Invalid key is not an actual error, just means we do not store an entry in this index
                 return;
             }

--- a/src/lib/Index.ts
+++ b/src/lib/Index.ts
@@ -1,6 +1,6 @@
 import FDBKeyRange from "../FDBKeyRange";
 import FDBTransaction from "../FDBTransaction";
-import { ConstraintError } from "./errors";
+import { newConstraintError } from "./errors";
 import extractKey from "./extractKey";
 import ObjectStore from "./ObjectStore";
 import RecordStore from "./RecordStore";
@@ -92,7 +92,7 @@ class Index {
         try {
             indexKey = extractKey(this.keyPath, newRecord.value);
         } catch (err) {
-            if (err.name === "DataError") {
+            if (err.name === "newDataError") {
                 // Invalid key is not an actual error, just means we do not store an entry in this index
                 return;
             }
@@ -126,7 +126,7 @@ class Index {
             if (this.unique) {
                 const existingRecord = this.records.get(indexKey);
                 if (existingRecord) {
-                    throw new ConstraintError();
+                    throw newConstraintError();
                 }
             }
         } else {
@@ -134,7 +134,7 @@ class Index {
                 for (const individualIndexKey of indexKey) {
                     const existingRecord = this.records.get(individualIndexKey);
                     if (existingRecord) {
-                        throw new ConstraintError();
+                        throw newConstraintError();
                     }
                 }
             }

--- a/src/lib/KeyGenerator.ts
+++ b/src/lib/KeyGenerator.ts
@@ -1,4 +1,4 @@
-import { ConstraintError } from "./errors";
+import { newConstraintError } from "./errors";
 
 const MAX_KEY = 9007199254740992;
 
@@ -8,7 +8,7 @@ class KeyGenerator {
 
     public next() {
         if (this.num >= MAX_KEY) {
-            throw new ConstraintError();
+            throw newConstraintError();
         }
 
         this.num += 1;

--- a/src/lib/ObjectStore.ts
+++ b/src/lib/ObjectStore.ts
@@ -1,6 +1,6 @@
 import FDBKeyRange from "../FDBKeyRange";
 import Database from "./Database";
-import { ConstraintError, DataError } from "./errors";
+import { newConstraintError, newDataError } from "./errors";
 import extractKey from "./extractKey";
 import Index from "./Index";
 import KeyGenerator from "./KeyGenerator";
@@ -122,7 +122,7 @@ class ObjectStore {
                 let i = 0; // Just to run the loop at least once
                 while (i >= 0) {
                     if (typeof object !== "object") {
-                        throw new DataError();
+                        throw newDataError();
                     }
 
                     i = remainingKeyPath.indexOf(".");
@@ -152,7 +152,7 @@ class ObjectStore {
         const existingRecord = this.records.get(newRecord.key);
         if (existingRecord) {
             if (noOverwrite) {
-                throw new ConstraintError();
+                throw newConstraintError();
             }
             this.deleteRecord(newRecord.key, rollbackLog);
         }

--- a/src/lib/cmp.ts
+++ b/src/lib/cmp.ts
@@ -1,4 +1,4 @@
-import { DataError } from "./errors";
+import { newDataError } from "./errors";
 import valueToKey from "./valueToKey";
 
 const getType = (x: any) => {
@@ -18,7 +18,7 @@ const getType = (x: any) => {
         return "Binary";
     }
 
-    throw new DataError();
+    throw newDataError();
 };
 
 // https://w3c.github.io/IndexedDB/#compare-two-keys

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -71,7 +71,7 @@ export function newReadOnlyError(
 export function newTransactionInactiveError(
     message = messages.TransactionInactiveError,
 ): DOMException {
-    return new DOMException(message, "newTransactionInactiveError");
+    return new DOMException(message, "TransactionInactiveError");
 }
 
 export function newVersionError(message = messages.VersionError): DOMException {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,5 +1,7 @@
 /* tslint:disable: max-classes-per-file max-line-length */
 
+global["DOMException"] = require("domexception"); // tslint:disable-line
+
 const messages = {
     AbortError:
         "A request was aborted, for example through a call to IDBTransaction.abort.",
@@ -22,82 +24,56 @@ const messages = {
         "An attempt was made to open a database using a lower version than the existing version.",
 };
 
-export class AbortError extends Error {
-    constructor(message = messages.AbortError) {
-        super();
-        this.name = "AbortError";
-        this.message = message;
-    }
+export function newAbortError(message = messages.AbortError): DOMException {
+    return new DOMException(message, "AbortError");
 }
 
-export class ConstraintError extends Error {
-    constructor(message = messages.ConstraintError) {
-        super();
-        this.name = "ConstraintError";
-        this.message = message;
-    }
+export function newConstraintError(
+    message = messages.ConstraintError,
+): DOMException {
+    return new DOMException(message, "ConstraintError");
 }
 
-export class DataCloneError extends Error {
-    constructor(message = messages.DataCloneError) {
-        super();
-        this.name = "DataCloneError";
-        this.message = message;
-    }
+export function newDataCloneError(
+    message = messages.DataCloneError,
+): DOMException {
+    return new DOMException(message, "DataCloneError");
 }
 
-export class DataError extends Error {
-    constructor(message = messages.DataError) {
-        super();
-        this.name = "DataError";
-        this.message = message;
-    }
+export function newDataError(message = messages.DataError): DOMException {
+    return new DOMException(message, "DataError");
 }
 
-export class InvalidAccessError extends Error {
-    constructor(message = messages.InvalidAccessError) {
-        super();
-        this.name = "InvalidAccessError";
-        this.message = message;
-    }
+export function newInvalidAccessError(
+    message = messages.InvalidAccessError,
+): DOMException {
+    return new DOMException(message, "InvalidAccessError");
 }
 
-export class InvalidStateError extends Error {
-    constructor(message = messages.InvalidStateError) {
-        super();
-        this.name = "InvalidStateError";
-        this.message = message;
-    }
+export function newInvalidStateError(
+    message = messages.InvalidStateError,
+): DOMException {
+    return new DOMException(message, "InvalidStateError");
 }
 
-export class NotFoundError extends Error {
-    constructor(message = messages.NotFoundError) {
-        super();
-        this.name = "NotFoundError";
-        this.message = message;
-    }
+export function newNotFoundError(
+    message = messages.NotFoundError,
+): DOMException {
+    return new DOMException(message, "NotFoundError");
 }
 
-export class ReadOnlyError extends Error {
-    constructor(message = messages.ReadOnlyError) {
-        super();
-        this.name = "ReadOnlyError";
-        this.message = message;
-    }
+export function newReadOnlyError(
+    message = messages.ReadOnlyError,
+): DOMException {
+    return new DOMException(message, "ReadOnlyError");
 }
 
-export class TransactionInactiveError extends Error {
-    constructor(message = messages.TransactionInactiveError) {
-        super();
-        this.name = "TransactionInactiveError";
-        this.message = message;
-    }
+export function newTransactionInactiveError(
+    message = messages.TransactionInactiveError,
+): DOMException {
+    return new DOMException(message, "newTransactionInactiveError");
 }
 
-export class VersionError extends Error {
-    constructor(message = messages.VersionError) {
-        super();
-        this.name = "VersionError";
-        this.message = message;
-    }
+export function newVersionError(message = messages.VersionError): DOMException {
+    return new DOMException(message, "VersionError");
 }

--- a/src/lib/structuredClone.ts
+++ b/src/lib/structuredClone.ts
@@ -1,11 +1,11 @@
 const realisticStructuredClone = require("realistic-structured-clone"); // tslint:disable-line no-var-requires
-import { DataCloneError } from "./errors";
+import { newDataCloneError } from "./errors";
 
 const structuredClone = <T>(input: T): T => {
     try {
         return realisticStructuredClone(input);
     } catch (err) {
-        throw new DataCloneError();
+        throw newDataCloneError();
     }
 };
 

--- a/src/lib/valueToKey.ts
+++ b/src/lib/valueToKey.ts
@@ -1,17 +1,17 @@
-import { DataError } from "./errors";
+import { newDataError } from "./errors";
 import { Key } from "./types";
 
 // https://w3c.github.io/IndexedDB/#convert-a-value-to-a-input
 const valueToKey = (input: any, seen?: Set<object>): Key | Key[] => {
     if (typeof input === "number") {
         if (isNaN(input)) {
-            throw new DataError();
+            throw newDataError();
         }
         return input;
     } else if (input instanceof Date) {
         const ms = input.valueOf();
         if (isNaN(ms)) {
-            throw new DataError();
+            throw newDataError();
         }
         return new Date(ms);
     } else if (typeof input === "string") {
@@ -30,7 +30,7 @@ const valueToKey = (input: any, seen?: Set<object>): Key | Key[] => {
         if (seen === undefined) {
             seen = new Set();
         } else if (seen.has(input)) {
-            throw new DataError();
+            throw newDataError();
         }
         seen.add(input);
 
@@ -38,7 +38,7 @@ const valueToKey = (input: any, seen?: Set<object>): Key | Key[] => {
         for (let i = 0; i < input.length; i++) {
             const hop = input.hasOwnProperty(i);
             if (!hop) {
-                throw new DataError();
+                throw newDataError();
             }
             const entry = input[i];
             const key = valueToKey(entry, seen);
@@ -46,7 +46,7 @@ const valueToKey = (input: any, seen?: Set<object>): Key | Key[] => {
         }
         return keys;
     } else {
-        throw new DataError();
+        throw newDataError();
     }
 };
 

--- a/src/lib/valueToKeyRange.ts
+++ b/src/lib/valueToKeyRange.ts
@@ -1,5 +1,5 @@
 import FDBKeyRange from "../FDBKeyRange";
-import { DataError } from "./errors";
+import { newDataError } from "./errors";
 import valueToKey from "./valueToKey";
 
 // http://w3c.github.io/IndexedDB/#convert-a-value-to-a-key-range
@@ -10,7 +10,7 @@ const valueToKeyRange = (value: any, nullDisallowedFlag: boolean = false) => {
 
     if (value === null || value === undefined) {
         if (nullDisallowedFlag) {
-            throw new DataError();
+            throw newDataError();
         }
         return new FDBKeyRange(undefined, undefined, false, false);
     }

--- a/src/test/web-platform-tests/wpt-env.js
+++ b/src/test/web-platform-tests/wpt-env.js
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const DOMException = require("domexception");
 require("../../../auto");
 global.Event = require("../../../build/lib/FakeEvent").default;
 
@@ -19,7 +20,7 @@ global.document = {
     // this will instead use another object that also can't be used as a key.
     getElementsByTagName: () => Math,
 };
-global.DOMException = Error; // Kind of cheating for error-attributes.js
+global.DOMException = DOMException;
 global.location = {
     location: {},
 };


### PR DESCRIPTION
This ended up being harder than anticipated, mostly due to tooling.

For the most part, the change was simple. In `errors.ts`, I've replace `class SomeError extends Error` with `function newSomeError(...): DOMException`, and updated all callers.

However, there are two regressions and broken one tool, and I don't quite know how to fix them.

1. Regression one is that the w3c test in `src/test/web-platform-tests/converted/error-attributes.js` now fails (line 218).

2. (now fixed) ~Regression two is that the Mocha test `should allow index where not all records have keys` now fails~

3. Issue three is that qunit now fails altogether; this seems to be caused by the new `domexception` dependency using object spread notation [on line 15 of `webidl2js-wrapper.js`](https://github.com/jsdom/domexception/blob/696792281e474a68cc8fcb4db13dec4ca8a0762f/webidl2js-wrapper.js#L15).

Also, I had to do something a little hacky: after bashing my head on the wall trying to get TypeScript to recognize that the imported `DOMException` had the type of native `DOMException`, I eventually just did
```js
global['DOMException'] = require('domexception'); // ts:ignore-line
```
in order to sidestep both TypeScript and tslint.

I'm not sure how to resolve these issues, since I'm unfamiliar with the codebase and have never used phantomjs or qunit. I tried to look into the first two, but didn't really get very far. Any suggestions?