### PR TITLE
perf: use binary search for faster array operations

### DIFF
--- a/src/lib/RecordStore.ts
+++ b/src/lib/RecordStore.ts
@@ -1,4 +1,11 @@
 import FDBKeyRange from "../FDBKeyRange";
+import {
+    getByKey,
+    getByKeyRange,
+    getIndexByKey,
+    getIndexByKeyGTE,
+    getIndexByKeyRange,
+} from "./binarySearch";
 import cmp from "./cmp";
 import { Key, Record } from "./types";
 
@@ -7,14 +14,10 @@ class RecordStore {
 
     public get(key: Key | FDBKeyRange) {
         if (key instanceof FDBKeyRange) {
-            return this.records.find(record => {
-                return key.includes(record.key);
-            });
+            return getByKeyRange(this.records, key);
         }
 
-        return this.records.find(record => {
-            return cmp(record.key, key) === 0;
-        });
+        return getByKey(this.records, key);
     }
 
     public add(newRecord: Record) {
@@ -23,11 +26,7 @@ class RecordStore {
         if (this.records.length === 0) {
             i = 0;
         } else {
-            i = this.records.findIndex(record => {
-                // cmp will only return 0 for an index. For an object store, any matching key has already been deleted,
-                // but we still need to look for cmp = 1 to find where to insert.
-                return cmp(record.key, newRecord.key) >= 0;
-            });
+            i = getIndexByKeyGTE(this.records, newRecord.key);
 
             if (i === -1) {
                 // If no matching key, add to end
@@ -52,20 +51,19 @@ class RecordStore {
     }
 
     public delete(key: Key) {
-        const range = key instanceof FDBKeyRange ? key : FDBKeyRange.only(key);
-
         const deletedRecords: Record[] = [];
 
-        this.records = this.records.filter(record => {
-            const shouldDelete = range.includes(record.key);
-
-            if (shouldDelete) {
-                deletedRecords.push(record);
+        const isRange = key instanceof FDBKeyRange;
+        while (true) {
+            const idx = isRange
+                ? getIndexByKeyRange(this.records, key)
+                : getIndexByKey(this.records, key);
+            if (idx === -1) {
+                break;
             }
-
-            return !shouldDelete;
-        });
-
+            deletedRecords.push(this.records[idx]);
+            this.records.splice(idx, 1);
+        }
         return deletedRecords;
     }
 

--- a/src/lib/binarySearch.ts
+++ b/src/lib/binarySearch.ts
@@ -1,0 +1,91 @@
+import FDBKeyRange from "../FDBKeyRange";
+import cmp from "./cmp";
+import { Key, Record } from "./types";
+
+/**
+ * Classic binary search implementation. Returns the index where the key
+ * should be inserted, assuming the records list is ordered.
+ */
+function binarySearch(records: Record[], key: Key): number {
+    let low = 0;
+    let high = records.length;
+    let mid;
+    while (low < high) {
+        // tslint:disable-next-line:no-bitwise
+        mid = (low + high) >>> 1; // like Math.floor((low + high) / 2) but fast
+        if (cmp(records[mid].key, key) < 0) {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+    return low;
+}
+
+/**
+ * Equivalent to `records.findIndex(record => cmp(record.key, key) === 0)`
+ */
+export function getIndexByKey(records: Record[], key: Key): number {
+    const idx = binarySearch(records, key);
+    const record = records[idx];
+    if (record && cmp(record.key, key) === 0) {
+        return idx;
+    }
+    return -1;
+}
+
+/**
+ * Equivalent to `records.find(record => cmp(record.key, key) === 0)`
+ */
+export function getByKey(records: Record[], key: Key): Record | undefined {
+    const idx = getIndexByKey(records, key);
+    return records[idx];
+}
+
+/**
+ * Equivalent to `records.findIndex(record => key.includes(record.key))`
+ */
+export function getIndexByKeyRange(
+    records: Record[],
+    keyRange: FDBKeyRange,
+): number {
+    const lowerIdx =
+        typeof keyRange.lower === "undefined"
+            ? 0
+            : binarySearch(records, keyRange.lower);
+    const upperIdx =
+        typeof keyRange.upper === "undefined"
+            ? records.length - 1
+            : binarySearch(records, keyRange.upper);
+
+    for (let i = lowerIdx; i <= upperIdx; i++) {
+        const record = records[i];
+        if (keyRange.includes(record.key)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+/**
+ * Equivalent to `records.find(record => key.includes(record.key))`
+ */
+export function getByKeyRange(
+    records: Record[],
+    keyRange: FDBKeyRange,
+): Record | undefined {
+    const idx = getIndexByKeyRange(records, keyRange);
+    return records[idx];
+}
+
+/**
+ * Equivalent to `records.findIndex(record => cmp(record.key, key) >= 0)`
+ */
+export function getIndexByKeyGTE(records: Record[], key: Key): number {
+    const idx = binarySearch(records, key);
+    const record = records[idx];
+    if (record && cmp(record.key, key) >= 0) {
+        return idx;
+    }
+    return -1;
+}


### PR DESCRIPTION
Helps a lot with #44

This implements a binary search for most of the `RecordStore` operations - `get()`, `add()`, `delete()`. Using the benchmark mentioned in #44, running in Node v14 on Ubuntu on my XPS 13, I measured the following improvement (median of 3 iterations):

- Before: 30621ms
- After: 5506ms (**5.56x improvement**)

There are still further improvements that can be made (mostly in `RecordStore.add` in the value comparison), but I'm holding off since this PR is already big enough and 5.5x is already a pretty big improvement.

I considered switching to a completely different backing store, but that seemed like it would have been a lot of work. This way we can keep the existing Array backing store and just optimize some of the lookups.