### PR TITLE
Avoid processTransactions stall on tx with no requests

### DIFF
--- a/src/lib/Database.ts
+++ b/src/lib/Database.ts
@@ -36,10 +36,9 @@ class Database {
                 });
 
                 if (next) {
-                    next._start();
-
                     next.addEventListener("complete", this.processTransactions);
                     next.addEventListener("abort", this.processTransactions);
+                    next._start();
                 }
             }
         });


### PR DESCRIPTION
Possible fix for stall in Database.processTransactions if a transaction doesn't contain any requests: attach the event listeners to the transaction before starting it.

(Let me know if you'd prefer some other approach. Or I certainly won't be offended if you want to just modify the PR directly.)

Fixes #54