### PR TITLE
Add ability to generate type declaration files as part of build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 build
+lib/**/*.d.ts

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     ],
     "main": "build/index.js",
     "scripts": {
-        "build": "rm -rf build && tsc",
+        "build": "rm -rf build && tsc && npm run build-typedefs",
+        "build-typedefs": "rm -rf lib/**/*.d.ts && tsc --outDir ./lib --declaration --emitDeclarationOnly --target es5 --downlevelIteration ./src/FDB*.ts",
         "prepublishOnly": "npm run build && rm -rf build/test",
         "lint": "tslint  'src/**/*.ts'",
         "prettier": "prettier --write *.json  'src/**/*.{js,ts}'",


### PR DESCRIPTION
## Summary

This PR modifies the build script to include generating ambient type declaration files. The files are generated in the "legacy API" `lib/` folder so that the existing paths used to reference the CommonJS modules will continue to work with the Typescript compiler. For example, the Typescript compiler will not complain about the following:
```
import FDBFactory from 'fake-indexeddb/lib/FDBFactory'; // 👍 Resolves to lib/FDBFactory.js, and tsc is also happy because it sees lib/FDBFactory.d.ts
indexedDB = new FDBFactory();
```

## Changes
  - Adds a new `build-typedefs` npm script. This writes `.d.ts` files to the `lib/` directory.
  - Modifies the `build` npm script to to run `build-typedefs`.
  - Modifies `.gitignore` so that the type declaration files (`lib/*.d.ts`) are ignored.

## Example

```
$ yarn build-typedefs
```

_Result:_

```
 |-package.json
 |-lib
 | |-FDBDatabase.js
 | |-FDBDatabase.d.ts ✨
 | |-FDBIndex.js
 | |-FDBIndex.d.ts ✨
...
```

## How to try it out

I published a version with these changes to make it easier to test:
```
npm install -D @clintharris/fake-indexeddb
```