### PR TITLE
feat: configure nextMacroTask timer function #67

### DIFF
--- a/auto.js
+++ b/auto.js
@@ -33,3 +33,7 @@ globalVar.IDBOpenDBRequest = FDBOpenDBRequest;
 globalVar.IDBRequest = FDBRequest;
 globalVar.IDBTransaction = FDBTransaction;
 globalVar.IDBVersionChangeEvent = FDBVersionChangeEvent;
+
+module.exports = {
+    setNextMacroTask: require("./build/lib/nextMacroTask").setNextMacroTask,
+};

--- a/src/FDBDatabase.ts
+++ b/src/FDBDatabase.ts
@@ -9,6 +9,7 @@ import {
 } from "./lib/errors";
 import fakeDOMStringList from "./lib/fakeDOMStringList";
 import FakeEventTarget from "./lib/FakeEventTarget";
+import { nextMacroTask } from "./lib/nextMacroTask";
 import ObjectStore from "./lib/ObjectStore";
 import { FakeDOMStringList, KeyPath, TransactionMode } from "./lib/types";
 import validateKeyPath from "./lib/validateKeyPath";
@@ -53,7 +54,7 @@ const closeConnection = (connection: FDBDatabase) => {
             },
         );
     } else {
-        setImmediate(() => {
+        nextMacroTask(() => {
             closeConnection(connection);
         });
     }

--- a/src/FDBTransaction.ts
+++ b/src/FDBTransaction.ts
@@ -10,6 +10,7 @@ import {
 import fakeDOMStringList from "./lib/fakeDOMStringList";
 import FakeEvent from "./lib/FakeEvent";
 import FakeEventTarget from "./lib/FakeEventTarget";
+import { nextMacroTask } from "./lib/nextMacroTask";
 import {
     EventCallback,
     FakeDOMStringList,
@@ -80,7 +81,7 @@ class FDBTransaction extends FakeEventTarget {
             }
         }
 
-        setImmediate(() => {
+        nextMacroTask(() => {
             const event = new FakeEvent("abort", {
                 bubbles: true,
                 cancelable: false,
@@ -228,7 +229,7 @@ class FDBTransaction extends FakeEventTarget {
             }
 
             // Give it another chance for new handlers to be set before finishing
-            setImmediate(this._start.bind(this));
+            nextMacroTask(this._start.bind(this));
             return;
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import fakeIndexedDB from "./fakeIndexedDB";
 
-module.exports = fakeIndexedDB;
+export default fakeIndexedDB;
+export { setNextMacroTask } from "./lib/nextMacroTask";

--- a/src/lib/Database.ts
+++ b/src/lib/Database.ts
@@ -1,5 +1,6 @@
 import FDBDatabase from "../FDBDatabase";
 import FDBTransaction from "../FDBTransaction";
+import { nextMacroTask } from "./nextMacroTask";
 import ObjectStore from "./ObjectStore";
 
 // http://www.w3.org/TR/2015/REC-IndexedDB-20150108/#dfn-database
@@ -20,7 +21,7 @@ class Database {
     }
 
     public processTransactions() {
-        setImmediate(() => {
+        nextMacroTask(() => {
             const anyRunning = this.transactions.some(transaction => {
                 return (
                     transaction._started && transaction._state !== "finished"

--- a/src/lib/nextMacroTask.ts
+++ b/src/lib/nextMacroTask.ts
@@ -1,0 +1,15 @@
+// This polyfill should probably be removed on a major release.
+// Projects requiring this polyfill could then set it up themselves.
+import "setimmediate";
+
+type NextMacroTask = (callback: () => void) => void;
+
+let timingFunc: NextMacroTask = setImmediate;
+
+export function setNextMacroTask(func: NextMacroTask) {
+    timingFunc = func;
+}
+
+export function nextMacroTask(callback: () => void) {
+    return timingFunc(callback);
+}


### PR DESCRIPTION
This change allows to replace calls to `setImmediate` (or the polyfill) e.g. in `jsdom` environment:
```js
import { setNextMacroTask } from 'fake-indexeddb/auto'
setNextMacroTask(setTimeout)
```

```js
import indexedDB, { setNextMacroTask } from 'fake-indexeddb'
setNextMacroTask(setTimeout)
```

Closes #67 
Closes #64 