### PR TITLE
Fix error when adding undefined or null children in indexed objects

### DIFF
--- a/src/lib/extractKey.ts
+++ b/src/lib/extractKey.ts
@@ -43,7 +43,11 @@ const extractKey = (keyPath: KeyPath, value: Value) => {
             remainingKeyPath = null;
         }
 
-        if (!object.hasOwnProperty(identifier)) {
+        if (
+            object === undefined ||
+            object === null ||
+            !object.hasOwnProperty(identifier)
+        ) {
             return;
         }
 


### PR DESCRIPTION
Confirmed that this matches browser behavior in Firefox and Chrome