### PR TITLE
Added the FDBCursor.request accessor.

### DIFF
--- a/src/FDBCursor.ts
+++ b/src/FDBCursor.ts
@@ -108,6 +108,13 @@ class FDBCursor {
         /* For babel */
     }
 
+    get request() {
+        return this._request;
+    }
+    set request(val) {
+        /* For babel */
+    }
+
     get direction() {
         return this._direction;
     }


### PR DESCRIPTION
This PR adds the readonly property for the request to the FDBCursor class.  This property exists in the spec, but seems to be missing in the implementation:

https://developer.mozilla.org/en-US/docs/Web/API/IDBCursor/request