### PR TITLE
docs: Import auto first to work with Dexie

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,9 @@ As of version 4, fake-indexeddb includes TypeScript types. As you can see in typ
 
 ### Dexie and other IndexedDB API wrappers
 
-If you import `fake-indexeddb/auto` before calling `new Dexie()`, it should work:
+If you import `fake-indexeddb/auto` before importing `dexie`, it should work:
 
 ```js
-// import fake-indexeddb/auto first to make Dexie works correctly
 import "fake-indexeddb/auto";
 import Dexie from "dexie";
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ As of version 4, fake-indexeddb includes TypeScript types. As you can see in typ
 If you import `fake-indexeddb/auto` before calling `new Dexie()`, it should work:
 
 ```js
-import Dexie from "dexie";
+// import fake-indexeddb/auto first to make Dexie works correctly
 import "fake-indexeddb/auto";
+import Dexie from "dexie";
 
 const db = new Dexie("MyDatabase");
 ```


### PR DESCRIPTION
Dexie's default option is [statically](https://github.com/dexie/Dexie.js/blob/6511b0f35fb8b307ca0ebb9d88870a70e440f18d/src/classes/dexie/dexie-dom-dependencies.ts#L9) assigned to its [constructor](https://github.com/dexie/Dexie.js/blob/master/src/classes/dexie/dexie-static-props.ts#L214), so we should import `fake-indexeddb/auto` first to make sure it works as expected