### PR TITLE
Fix issue #98: workaround to check date object

### DIFF
--- a/src/lib/valueToKey.ts
+++ b/src/lib/valueToKey.ts
@@ -8,7 +8,7 @@ const valueToKey = (input: any, seen?: Set<object>): Key | Key[] => {
             throw new DataError();
         }
         return input;
-    } else if (input instanceof Date) {
+    } else if (Object.prototype.toString.call(input) === "[object Date]") {
         const ms = input.valueOf();
         if (isNaN(ms)) {
             throw new DataError();


### PR DESCRIPTION
To solve  the problem that global Date is not same function  when using in jest + jsdom or between frames.