### PR TITLE
Descriptive error message when DB version is 0

### DIFF
--- a/src/FDBFactory.ts
+++ b/src/FDBFactory.ts
@@ -270,7 +270,7 @@ class FDBFactory {
             version = enforceRange(version, "MAX_SAFE_INTEGER");
         }
         if (version === 0) {
-            throw new TypeError();
+            throw new TypeError("Database version cannot be 0");
         }
 
         const request = new FDBOpenDBRequest();


### PR DESCRIPTION
Function at `src/FDBFactory.ts:273` already throws an error if the version parameter is 0, just added a message to that error to improve clarity (currently throws empty `TypeError`).