### PR TITLE
Switch from package type to resolve issues with bun

### DIFF
--- a/auto/package.json
+++ b/auto/package.json
@@ -1,3 +1,3 @@
 {
-    "type": "commonjs"
+    "type": "module"
 }


### PR DESCRIPTION
Switch from package type of `commonjs` to `module` to resolve issues with bun imports.