### PR TITLE
Fix tests in Node 18 and 20

### DIFF
--- a/src/test/web-platform-tests/run-all.js
+++ b/src/test/web-platform-tests/run-all.js
@@ -5,6 +5,9 @@ import { glob } from "glob";
 const __dirname = "src/test/web-platform-tests";
 const testFolder = path.join(__dirname, "converted");
 
+/* global process */
+const nodeMajorVersion = parseInt(process.version.substring(1).split(".")[0]);
+
 let passed = 0;
 let failed = 0;
 let skipped = new Set();
@@ -160,6 +163,24 @@ const skip = [
 
     // test hangs, needs further investigation
     "transaction-lifetime.any.js",
+
+    // These break in Node <20 because of lack of support for `ArrayBuffer.prototype.detached`
+    ...(nodeMajorVersion < 22
+        ? [
+              "idb_binary_key_conversion.any.js",
+              "idb-binary-key-detached.any.js",
+              "idbindex_getAll.any.js",
+              "idbindex_getAllKeys.any.js",
+              "idbindex_getAllKeys-options.tentative.any.js",
+              "idbindex_getAll-options.tentative.any.js",
+              "idbindex_getAllRecords.tentative.any.js",
+              "idbobjectstore_getAll.any.js",
+              "idbobjectstore_getAllKeys.any.js",
+              "idbobjectstore_getAllKeys-options.tentative.any.js",
+              "idbobjectstore_getAll-options.tentative.any.js",
+              "idbobjectstore_getAllRecords.tentative.any.js",
+          ]
+        : []),
 ];
 
 if (new Set(skip).size !== skip.length) {


### PR DESCRIPTION
I noticed that #117 is now causing [a test failure](https://github.com/dumbmatter/fakeIndexedDB/actions/runs/16834146028/job/47689203888) for Node 18 and 20. This appears to be due to the `Empty ArrayBuffer` logic in `idb_binary_key_conversion.any.js` plus various `get_all_with_invalid_keys_test` tests, since Node <22's `ArrayBuffer` doesn't have a `detached` property so our detachedness check is not working correctly.

The simplest fix here IMO is to disable these tests for Node 18 and 20. `ArrayBuffer` detachedness is a pretty minor feature so it's not worth trying to support in Node 18 and 22 (nor do I think there' s a straightforward way to do it).