### PR TITLE
Switch WPT tests to `node:test` runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "test-mocha": "mocha --timeout 10000 build/esm/test/fakeIndexedDB",
         "build-qunit": "mkdir build/esm/test/indexedDBmock && cp src/test/indexedDBmock/* build/esm/test/indexedDBmock && browserify src/test/indexedDBmock/exports-qunit-bundle.js -o build/esm/test/indexedDBmock/exports-qunit-bundle.js -t [ babelify --presets [ @babel/preset-env ] ]",
         "test-qunit": "pnpm run build-qunit && OPENSSL_CONF=/dev/null node-qunit-phantomjs build/esm/test/indexedDBmock/index.html",
-        "test-w3c": "node src/test/web-platform-tests/run-all.js",
+        "test-w3c": "node --test src/test/web-platform-tests/run-all.js",
         "test": "pnpm run lint && pnpm run build && pnpm run test-jest && node test/test.js && node test/dexie.js && pnpm run test-w3c && pnpm run test-mocha && pnpm run test-qunit",
         "prepare": "husky"
     },

--- a/src/test/web-platform-tests/README.md
+++ b/src/test/web-platform-tests/README.md
@@ -1,5 +1,22 @@
 These tests come from [web-platform-tests](https://github.com/w3c/web-platform-tests/tree/master/IndexedDB), last copied in August 2025 from commit [`226fbab4280e1a55cb09cd7a2ba3aa9d88fea53f`](https://github.com/web-platform-tests/wpt/commit/226fbab4280e1a55cb09cd7a2ba3aa9d88fea53f).
 
+## Running the tests
+
+To run all the tests:
+
+```sh
+pnpm run test-w3c
+```
+
+To run a subset of the tests:
+
+```sh
+node --test --test-name-pattern="name of test" \
+    ./src/test/web-platform-tests/run-all.js
+```
+
+## Updating the tests
+
 To update the tests, copy over the `IndexedDB` folder and remove `converted`:
 
 ```sh

--- a/src/test/web-platform-tests/convert.js
+++ b/src/test/web-platform-tests/convert.js
@@ -134,6 +134,19 @@ const outFolder = path.posix.join(__dirname, "converted");
             codeChunks.push(declareGlobalVars);
         }
 
+        if (testScript.includes("title=")) {
+            console.log("found!");
+        }
+        const titleMatches = [
+            ...testScript.matchAll(/\/\/\s*META:\s*title=(.+)$/gm),
+        ];
+        if (titleMatches.length) {
+            // some tests use `self.title` to create the test name
+            codeChunks.push(
+                `globalThis.title = ${JSON.stringify(titleMatches[0][1])};\n`,
+            );
+        }
+
         const importMatches = testScript
             .matchAll(/^\/\/\s*META:\s*script=(.+)$/gm)
             .filter(

--- a/src/test/web-platform-tests/converted/abort-in-initial-upgradeneeded.any.js
+++ b/src/test/web-platform-tests/converted/abort-in-initial-upgradeneeded.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/bindings-inject-keys-bypass.any.js
+++ b/src/test/web-platform-tests/converted/bindings-inject-keys-bypass.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: ES bindings - Inject a key into a value - Keys bypass setters";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/bindings-inject-values-bypass.any.js
+++ b/src/test/web-platform-tests/converted/bindings-inject-values-bypass.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: ES bindings - Inject a key into a value - Values bypass chain and setters";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/blob-composite-blob-reads.any.js
+++ b/src/test/web-platform-tests/converted/blob-composite-blob-reads.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDB-backed composite blobs maintain coherency";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/blob-contenttype.any.js
+++ b/src/test/web-platform-tests/converted/blob-contenttype.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Blob Content Type";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/blob-delete-objectstore-db.any.js
+++ b/src/test/web-platform-tests/converted/blob-delete-objectstore-db.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Blob Delete Object Store";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/blob-valid-after-abort.any.js
+++ b/src/test/web-platform-tests/converted/blob-valid-after-abort.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Blob Valid After Abort";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/blob-valid-after-deletion.any.js
+++ b/src/test/web-platform-tests/converted/blob-valid-after-deletion.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Blob Valid After Deletion";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/blob-valid-before-commit.any.js
+++ b/src/test/web-platform-tests/converted/blob-valid-before-commit.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Blob Valid Before Commit";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/clone-before-keypath-eval.any.js
+++ b/src/test/web-platform-tests/converted/clone-before-keypath-eval.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: clone before key path evaluation";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/close-in-upgradeneeded.any.js
+++ b/src/test/web-platform-tests/converted/close-in-upgradeneeded.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/cursor-overloads.any.js
+++ b/src/test/web-platform-tests/converted/cursor-overloads.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/delete-range.any.js
+++ b/src/test/web-platform-tests/converted/delete-range.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Delete range";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/delete-request-queue.any.js
+++ b/src/test/web-platform-tests/converted/delete-request-queue.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/error-attributes.any.js
+++ b/src/test/web-platform-tests/converted/error-attributes.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/event-dispatch-active-flag.any.js
+++ b/src/test/web-platform-tests/converted/event-dispatch-active-flag.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB Transaction - active flag is set during event dispatch";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/fire-error-event-exception.any.js
+++ b/src/test/web-platform-tests/converted/fire-error-event-exception.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Fire error event - Exception thrown";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/fire-success-event-exception.any.js
+++ b/src/test/web-platform-tests/converted/fire-success-event-exception.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Fire success event - Exception thrown";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/fire-upgradeneeded-event-exception.any.js
+++ b/src/test/web-platform-tests/converted/fire-upgradeneeded-event-exception.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Fire upgradeneeded event - Exception thrown";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/globalscope-indexedDB-SameObject.any.js
+++ b/src/test/web-platform-tests/converted/globalscope-indexedDB-SameObject.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Verify [SameObject] behavior of the global scope's indexedDB attribute";
+
 // META: title=IndexedDB: Verify [SameObject] behavior of the global scope's indexedDB attribute
 // META: global=window,worker
 

--- a/src/test/web-platform-tests/converted/historical.any.js
+++ b/src/test/web-platform-tests/converted/historical.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Historical features";
+
 // META: title=IndexedDB: Historical features
 // META: global=window,worker
 

--- a/src/test/web-platform-tests/converted/idb-binary-key-detached.any.js
+++ b/src/test/web-platform-tests/converted/idb-binary-key-detached.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = " IndexedDB: Detached buffers supplied as binary keys";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idb-binary-key-roundtrip.any.js
+++ b/src/test/web-platform-tests/converted/idb-binary-key-roundtrip.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Binary keys written to a database and read back";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idb_binary_key_conversion.any.js
+++ b/src/test/web-platform-tests/converted/idb_binary_key_conversion.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Verify the conversion of various types of BufferSource";
+
 // META: title=Verify the conversion of various types of BufferSource
 // META: global=window,worker
 

--- a/src/test/web-platform-tests/converted/idbcursor-advance-continue-async.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-advance-continue-async.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor asyncness";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-advance-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-advance-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBCursor advance() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-advance-invalid.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-advance-invalid.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.advance() - invalid";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-advance.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-advance.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.advance()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-continue-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-continue-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBCursor continue() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-continue.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-continue.any.js
@@ -1,5 +1,7 @@
 import "../wpt-env.js";
 
+globalThis.title = "IDBCursor.continue()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.continuePrimaryKey() - Exception Orders";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey-exceptions.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey-exceptions.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBCursor continuePrimaryKey() exception throwing";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBCursor method continuePrimaryKey()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-delete-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-delete-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBCursor delete() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-direction-index-keyrange.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-direction-index-keyrange.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor direction - index with keyrange";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-direction-index.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-direction-index.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor direction - index";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-direction-objectstore-keyrange.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-direction-objectstore-keyrange.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor direction - object store with keyrange";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-direction-objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-direction-objectstore.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor direction - object store";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-direction.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-direction.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.direction";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-iterating-update.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-iterating-update.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Index iteration with cursor updates/deletes";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-key.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-key.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.key";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-primarykey.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-primarykey.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.primaryKey";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-request-source.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-request-source.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: The source of requests made against cursors";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-reused.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-reused.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor is reused";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-source.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-source.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.source";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor-update-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-update-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBCursor update() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor_advance_index.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_advance_index.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.advance()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor_advance_objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_advance_objectstore.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.advance()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor_continue_delete_objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_continue_delete_objectstore.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.delete() and IDBCursor.continue()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor_continue_index.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_continue_index.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.continue() - index";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor_continue_invalid.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_continue_invalid.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.continue()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor_continue_objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_continue_objectstore.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.continue() - object store";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor_delete_index.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_delete_index.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.delete() - index";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor_delete_objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_delete_objectstore.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.delete() - object store";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor_iterating.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_iterating.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.continue() - object store";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor_update_index.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_update_index.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.update() - index";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbcursor_update_objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_update_objectstore.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBCursor.update() - object store";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbdatabase-createObjectStore-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase-createObjectStore-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBDatabase createObjectStore() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbdatabase-deleteObjectStore-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase-deleteObjectStore-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBDatabase deleteObjectStore() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbdatabase-transaction-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase-transaction-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBDatabase transaction() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbdatabase_close.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase_close.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBDatabase.close()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbdatabase_createObjectStore.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase_createObjectStore.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBDatabase.createObjectStore()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbdatabase_deleteObjectStore.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase_deleteObjectStore.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBDatabase.deleteObjectStore()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbdatabase_transaction.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase_transaction.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBDatabase.transaction()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbfactory-deleteDatabase-request-success.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory-deleteDatabase-request-success.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBFactory deleteDatabase()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbfactory-open-error-properties.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory-open-error-properties.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBFactory open() error event properties";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbfactory-open-request-error.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory-open-request-error.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBFactory open(): request properties on error";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbfactory-open-request-success.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory-open-request-success.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBFactory open(): request properties on success";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbfactory_cmp.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory_cmp.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBFactory.cmp()";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/idbfactory_deleteDatabase.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory_deleteDatabase.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBFactory.deleteDatabase()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbfactory_open.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory_open.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBFactory.open()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex-getAll-enforcerange.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-getAll-enforcerange.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBIndex getAll() uses [EnforceRange]";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex-getAllKeys-enforcerange.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-getAllKeys-enforcerange.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBIndex getAllKeys() uses [EnforceRange]";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex-multientry.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-multientry.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBIndex.multiEntry";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex-objectStore-SameObject.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-objectStore-SameObject.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: objectStore SameObject";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex-query-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-query-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBIndex query method Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex-rename-abort.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-rename-abort.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: index renaming support in aborted transactions";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/idbindex-rename-errors.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-rename-errors.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: index renaming error handling";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/idbindex-rename.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-rename.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: index renaming support";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/idbindex-request-source.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-request-source.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: The source of requests made against indexes";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex_count.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_count.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBIndex.count()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex_get.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_get.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBIndex.get()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex_getAll-options.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getAll-options.tentative.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBIndex.getAll with options dictionary.";
+
 'use strict';
 
 // Should be large enough to trigger large value handling in the IndexedDB

--- a/src/test/web-platform-tests/converted/idbindex_getAll.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getAll.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBIndex.getAll";
+
 'use strict';
 
 // Should be large enough to trigger large value handling in the IndexedDB

--- a/src/test/web-platform-tests/converted/idbindex_getAllKeys-options.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getAllKeys-options.tentative.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBIndex.getAllKeys with options dictionary.";
+
 'use strict';
 
 // Should be large enough to trigger large value handling in the IndexedDB

--- a/src/test/web-platform-tests/converted/idbindex_getAllKeys.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getAllKeys.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBIndex.getAllKeys.";
+
 'use strict';
 
 // Should be large enough to trigger large value handling in the IndexedDB

--- a/src/test/web-platform-tests/converted/idbindex_getAllRecords.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getAllRecords.tentative.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBIndex.getAllRecords";
+
 'use strict';
 
 // Should be large enough to trigger large value handling in the IndexedDB

--- a/src/test/web-platform-tests/converted/idbindex_getKey.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getKey.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBIndex.getKey()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex_indexNames.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_indexNames.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.indexNames";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex_keyPath.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_keyPath.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBIndex keyPath attribute";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex_openCursor.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_openCursor.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBIndex.openCursor()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex_openKeyCursor.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_openKeyCursor.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBIndex.openKeyCursor()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbindex_reverse_cursor.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_reverse_cursor.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Reverse Cursor Validity";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/idbindex_tombstones.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_tombstones.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Index Tombstones";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/idbkeyrange-includes.any.js
+++ b/src/test/web-platform-tests/converted/idbkeyrange-includes.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBKeyRange.includes()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbkeyrange.any.js
+++ b/src/test/web-platform-tests/converted/idbkeyrange.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBKeyRange Tests";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbkeyrange_incorrect.any.js
+++ b/src/test/web-platform-tests/converted/idbkeyrange_incorrect.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBKeyRange Tests - Incorrect";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore-add-put-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-add-put-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBObjectStore add()/put() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore-clear-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-clear-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBObjectStore clear() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore-delete-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-delete-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBObjectStore delete() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore-deleteIndex-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-deleteIndex-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBObjectStore deleteIndex() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore-getAll-enforcerange.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-getAll-enforcerange.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBObjectStore getAll() uses [EnforceRange]";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore-getAllKeys-enforcerange.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-getAllKeys-enforcerange.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBIObjectStore getAllKeys() uses [EnforceRange]";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore-index-finished.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-index-finished.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBObjectStore index() when transaction is finished";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore-query-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-query-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBObjectStore query method Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore-rename-abort.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-rename-abort.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: object store renaming support in aborted transactions";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/idbobjectstore-rename-errors.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-rename-errors.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: object store renaming error handling";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/idbobjectstore-rename-store.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-rename-store.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: object store renaming support";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/idbobjectstore-request-source.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-request-source.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: The source of requests made against object stores";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore-transaction-SameObject.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-transaction-SameObject.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Verify [SameObject] behavior of IDBObjectStore's transaction attribute";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_add.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_add.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.add()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_clear.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_clear.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.clear()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_count.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_count.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.count()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_createIndex.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_createIndex.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.createIndex()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_delete.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_delete.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.delete()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_deleteIndex.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_deleteIndex.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.deleteIndex()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_get.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_get.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.get()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_getAll-options.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getAll-options.tentative.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBObjectStore.getAll with options dictionary.";
+
 'use strict';
 
 // Should be large enough to trigger large value handling in the IndexedDB

--- a/src/test/web-platform-tests/converted/idbobjectstore_getAll.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getAll.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBObjectStore.getAll";
+
 'use strict';
 
 // Should be large enough to trigger large value handling in the IndexedDB

--- a/src/test/web-platform-tests/converted/idbobjectstore_getAllKeys-options.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getAllKeys-options.tentative.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBObjectStore.getAllKeys with options dictionary.";
+
 'use strict';
 
 // Should be large enough to trigger large value handling in the IndexedDB

--- a/src/test/web-platform-tests/converted/idbobjectstore_getAllKeys.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getAllKeys.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBObjectStore.getAllKeys";
+
 'use strict';
 
 // Should be large enough to trigger large value handling in the IndexedDB

--- a/src/test/web-platform-tests/converted/idbobjectstore_getAllRecords.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getAllRecords.tentative.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBObjectStore.getAllRecords";
+
 'use strict';
 
 // Should be large enough to trigger large value handling in the IndexedDB

--- a/src/test/web-platform-tests/converted/idbobjectstore_getKey.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getKey.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test IDBObjectStore.getKey()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_index.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_index.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.index() - returns an index";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_keyPath.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_keyPath.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBObjectStore keyPath attribute - same object";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_openCursor.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_openCursor.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.openCursor() - iterate through 100 objects";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_openCursor_invalid.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_openCursor_invalid.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.openCursor() - invalid";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_openKeyCursor.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_openKeyCursor.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.openKeyCursor()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbobjectstore_put.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_put.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore.put()";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbrequest-onupgradeneeded.any.js
+++ b/src/test/web-platform-tests/converted/idbrequest-onupgradeneeded.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBRequest onupgradeneeded tests";
+
 // META: title=IDBRequest onupgradeneeded tests
 // META: global=window,worker
 

--- a/src/test/web-platform-tests/converted/idbrequest_error.any.js
+++ b/src/test/web-platform-tests/converted/idbrequest_error.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBRequest.error";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbrequest_result.any.js
+++ b/src/test/web-platform-tests/converted/idbrequest_result.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBRequest.result";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbtransaction-db-SameObject.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction-db-SameObject.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Verify [SameObject] behavior of IDBTransaction's db attribute";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbtransaction-objectStore-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction-objectStore-exception-order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBTransaction objectStore() Exception Ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbtransaction-objectStore-finished.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction-objectStore-finished.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBTransaction objectStore() when transaction is finished";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbtransaction-oncomplete.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction-oncomplete.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBTransaction - complete event";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbtransaction.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBTransaction";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbtransaction_abort.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction_abort.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBTransaction - abort";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbtransaction_objectStoreNames.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction_objectStoreNames.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: IDBTransaction.objectStoreNames attribute";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/idbversionchangeevent.any.js
+++ b/src/test/web-platform-tests/converted/idbversionchangeevent.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBVersionChangeEvent";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/index_sort_order.any.js
+++ b/src/test/web-platform-tests/converted/index_sort_order.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = " IDBIndex Key sort order";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/interleaved-cursors-large.any.js
+++ b/src/test/web-platform-tests/converted/interleaved-cursors-large.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Interleaved iteration of multiple cursors";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/interleaved-cursors-small.any.js
+++ b/src/test/web-platform-tests/converted/interleaved-cursors-small.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Interleaved iteration of multiple cursors";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/key-conversion-exceptions.any.js
+++ b/src/test/web-platform-tests/converted/key-conversion-exceptions.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Exceptions thrown during key conversion";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/key_invalid.any.js
+++ b/src/test/web-platform-tests/converted/key_invalid.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Invalid key";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/key_valid.any.js
+++ b/src/test/web-platform-tests/converted/key_valid.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Valid key";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/keyorder.any.js
+++ b/src/test/web-platform-tests/converted/keyorder.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Key sort order";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/keypath-exceptions.any.js
+++ b/src/test/web-platform-tests/converted/keypath-exceptions.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Exceptions in extracting keys from values (ES bindings)";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/keypath-special-identifiers.any.js
+++ b/src/test/web-platform-tests/converted/keypath-special-identifiers.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Special-cased identifiers in extracting keys from values (ES bindings)";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/keypath.any.js
+++ b/src/test/web-platform-tests/converted/keypath.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Keypath";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/keypath_invalid.any.js
+++ b/src/test/web-platform-tests/converted/keypath_invalid.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Invalid keypath";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/keypath_maxsize.any.js
+++ b/src/test/web-platform-tests/converted/keypath_maxsize.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Keypath";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/large-requests-abort.any.js
+++ b/src/test/web-platform-tests/converted/large-requests-abort.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: transactions with large request results are aborted correctly";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/list_ordering.any.js
+++ b/src/test/web-platform-tests/converted/list_ordering.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "ObjectStoreNames and indexNames ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/name-scopes.any.js
+++ b/src/test/web-platform-tests/converted/name-scopes.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: scoping for database / object store / index names, and index keys";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/nested-cloning-basic.any.js
+++ b/src/test/web-platform-tests/converted/nested-cloning-basic.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: basic objects are cloned correctly";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/nested-cloning-large-multiple.any.js
+++ b/src/test/web-platform-tests/converted/nested-cloning-large-multiple.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: large nested objects are cloned correctly";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/nested-cloning-large.any.js
+++ b/src/test/web-platform-tests/converted/nested-cloning-large.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: large nested objects are cloned correctly";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/nested-cloning-small.any.js
+++ b/src/test/web-platform-tests/converted/nested-cloning-small.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: small nested objects are cloned correctly";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/objectstore_keyorder.any.js
+++ b/src/test/web-platform-tests/converted/objectstore_keyorder.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IDBObjectStore key sort order";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/open-request-queue.any.js
+++ b/src/test/web-platform-tests/converted/open-request-queue.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: open and delete request queues";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/parallel-cursors-upgrade.any.js
+++ b/src/test/web-platform-tests/converted/parallel-cursors-upgrade.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Parallel iteration of cursors in upgradeneeded";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/request-abort-ordering.any.js
+++ b/src/test/web-platform-tests/converted/request-abort-ordering.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: request abort events are delivered in order";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/request-event-ordering-large-mixed-with-small-values.any.js
+++ b/src/test/web-platform-tests/converted/request-event-ordering-large-mixed-with-small-values.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: request result events are delivered in order";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/request-event-ordering-large-then-small-values.any.js
+++ b/src/test/web-platform-tests/converted/request-event-ordering-large-then-small-values.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: request result events are delivered in order";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/request-event-ordering-large-values.any.js
+++ b/src/test/web-platform-tests/converted/request-event-ordering-large-values.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: request result events are delivered in order";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/request-event-ordering-small-values.any.js
+++ b/src/test/web-platform-tests/converted/request-event-ordering-small-values.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: request result events are delivered in order";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/request_bubble-and-capture.any.js
+++ b/src/test/web-platform-tests/converted/request_bubble-and-capture.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Bubbling and capturing of request events";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/storage-buckets.https.any.js
+++ b/src/test/web-platform-tests/converted/storage-buckets.https.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Buckets API: Tests for indexedDB API.";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/string-list-ordering.any.js
+++ b/src/test/web-platform-tests/converted/string-list-ordering.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB string list ordering";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/structured-clone-transaction-state.any.js
+++ b/src/test/web-platform-tests/converted/structured-clone-transaction-state.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Indexed DB transaction state during Structured Serializing";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/structured-clone.any.js
+++ b/src/test/web-platform-tests/converted/structured-clone.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Indexed DB and Structured Serializing/Deserializing";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/transaction-abort-generator-revert.any.js
+++ b/src/test/web-platform-tests/converted/transaction-abort-generator-revert.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: aborting transactions reverts an object store's key generator state";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/transaction-abort-index-metadata-revert.any.js
+++ b/src/test/web-platform-tests/converted/transaction-abort-index-metadata-revert.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: aborting transactions reverts index metadata";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/transaction-abort-multiple-metadata-revert.any.js
+++ b/src/test/web-platform-tests/converted/transaction-abort-multiple-metadata-revert.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: aborting transactions reverts multiple operations on the same metadata";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/transaction-abort-object-store-metadata-revert.any.js
+++ b/src/test/web-platform-tests/converted/transaction-abort-object-store-metadata-revert.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: aborting transactions reverts object store metadata";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/transaction-abort-request-error.any.js
+++ b/src/test/web-platform-tests/converted/transaction-abort-request-error.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Test error events fired at requests from aborted transaction";
+
 'use strict';
 
 // Returns an IndexedDB database name that is unique to the test case.

--- a/src/test/web-platform-tests/converted/transaction-create_in_versionchange.any.js
+++ b/src/test/web-platform-tests/converted/transaction-create_in_versionchange.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB Transaction Creation During Version Change";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/transaction-deactivation-timing.any.js
+++ b/src/test/web-platform-tests/converted/transaction-deactivation-timing.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB Transaction Deactivation Timing";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/transaction-lifetime-empty.any.js
+++ b/src/test/web-platform-tests/converted/transaction-lifetime-empty.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: Commit ordering of empty transactions";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/transaction-lifetime.any.js
+++ b/src/test/web-platform-tests/converted/transaction-lifetime.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Event order when opening a second database when one connection is open already";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/transaction-requestqueue.any.js
+++ b/src/test/web-platform-tests/converted/transaction-requestqueue.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB Transaction Request Queue Handling";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/transaction_bubble-and-capture.any.js
+++ b/src/test/web-platform-tests/converted/transaction_bubble-and-capture.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB Transaction Event Bubbling and Capturing";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/upgrade-transaction-deactivation-timing.any.js
+++ b/src/test/web-platform-tests/converted/upgrade-transaction-deactivation-timing.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "Upgrade transaction deactivation timing";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-backend-aborted.any.js
+++ b/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-backend-aborted.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: backend-aborted versionchange transaction lifecycle";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-committed.any.js
+++ b/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-committed.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: committed versionchange transaction lifecycle";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-user-aborted.any.js
+++ b/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-user-aborted.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: user-abort()ed versionchange transaction lifecycle";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/value.any.js
+++ b/src/test/web-platform-tests/converted/value.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: keys and values";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/value_recursive.any.js
+++ b/src/test/web-platform-tests/converted/value_recursive.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB: recursive value";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/converted/writer-starvation.any.js
+++ b/src/test/web-platform-tests/converted/writer-starvation.any.js
@@ -2,6 +2,8 @@ import "../wpt-env.js";
 
 let attrs,cursor,db,store,store2;
 
+globalThis.title = "IndexedDB writer starvation test";
+
 /* Delete created databases
  *
  * Go through each finished test, see if it has an associated database. Close

--- a/src/test/web-platform-tests/run-all.js
+++ b/src/test/web-platform-tests/run-all.js
@@ -217,16 +217,17 @@ for (const absFilename of filenames) {
             console.error(stderr);
         }
         const results = Object.create(null);
-        try {
-            const resultLines = stdout
-                .split("\n")
-                .filter((_) => _.includes("testResult"))
-                .map((_) => JSON.parse(_));
-            for (const resultLine of resultLines) {
-                Object.assign(results, resultLine.testResult);
+        const resultLines = stdout
+            .split("\n")
+            .filter((_) => _.includes("testResult"))
+            .map((_) => JSON.parse(_));
+        for (const resultLine of resultLines) {
+            for (const name of Object.keys(resultLine.testResult)) {
+                if (name in results) {
+                    throw new Error(`Duplicate test results for ${name}`);
+                }
             }
-        } catch (err) {
-            throw new Error("Could not parse output from test", { cause: err });
+            Object.assign(results, resultLine.testResult);
         }
         if (!Object.keys(results).length) {
             throw new Error("Did not receive any test results from test");

--- a/src/test/web-platform-tests/run-all.js
+++ b/src/test/web-platform-tests/run-all.js
@@ -1,12 +1,16 @@
-import { execSync } from "node:child_process";
+/* global console */
+
+import { test } from "node:test";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
 import path from "node:path";
 import { glob } from "glob";
+
+const execAsync = promisify(exec);
 
 const __dirname = "src/test/web-platform-tests";
 const testFolder = path.join(__dirname, "converted");
 
-let passed = 0;
-let failed = 0;
 let skipped = new Set();
 
 const skip = [
@@ -179,42 +183,38 @@ if (new Set(skip).size !== skip.length) {
 const filenames = glob.sync("/**/*.js", { root: testFolder });
 for (const absFilename of filenames) {
     const filename = path.relative(testFolder, absFilename);
-    if (skip.includes(filename)) {
-        console.log(`Skipping ${filename}...\n`);
+    const shouldSkip = skip.includes(filename);
+    if (shouldSkip) {
         skipped.add(filename);
-        continue;
     }
-
-    console.log(`Running ${filename}...`);
-    try {
-        const output = execSync(`node ${filename}`, {
+    await test(filename, { skip: shouldSkip }, async (t) => {
+        const { stdout, stderr } = await execAsync(`node ${filename}`, {
             cwd: testFolder,
-            // stdio: 'inherit'
+            encoding: "utf-8",
         });
-        if (output.toString().length > 0) {
-            console.log(output.toString());
+        if (stderr) {
+            console.error(stderr);
         }
-        console.log("Success!\n");
-        passed += 1;
-    } catch (err) {
-        console.log("");
-        failed += 1;
-    }
+        let results;
+        try {
+            results = JSON.parse(
+                stdout.split("\n").find((_) => _.includes("testResults")),
+            );
+        } catch (err) {
+            throw new Error("Could not parse output from test", { cause: err });
+        }
+        for (const [name, subResult] of Object.entries(results.testResults)) {
+            await t.test(name, () => {
+                if (!subResult.passed) {
+                    throw new Error(subResult.error);
+                }
+            });
+        }
+    });
 }
 
 if (skipped.size !== skip.length) {
     const extraneous = skip.filter((test) => !skipped.has(test));
     const errorMsg = `Skipped ${skipped.size} tests, but skip.length is ${skip.length}. Missing file? Extraneous files are: ${extraneous.join(", ")}`;
     throw new Error(errorMsg);
-}
-
-console.log(`Passed: ${passed}`);
-console.log(`Failed: ${failed}`);
-console.log(`Skipped: ${skipped.size}\n`);
-
-const pct = Math.round((100 * passed) / (passed + failed + skipped.size));
-console.log(`Success Rate: ${pct}%`);
-
-if (failed > 0) {
-    process.exit(1);
 }

--- a/src/test/web-platform-tests/wpt-env.js
+++ b/src/test/web-platform-tests/wpt-env.js
@@ -598,7 +598,7 @@ class AsyncTest {
             return fn.apply(this, args);
         } catch (err) {
             if (!this._completed) {
-                throw err;
+                this.fail(err);
             }
         }
     }
@@ -609,7 +609,7 @@ class AsyncTest {
                 fn.apply(this, args);
             } catch (err) {
                 if (!this._completed) {
-                    throw err;
+                    this.fail(err);
                 }
             }
         };


### PR DESCRIPTION
This is a baby-step toward #118. Rather than using our own test runner, this uses the built-in `node:test` runner. We still call each test's `*.js` file as a separate Node process, but we pass/fail it based on the serialized test results it sends back as `stdout`. We also explicitly `{ skip: true}` the skipped tests.

This makes the test output a lot nicer to look at, and also gives us some built-in benefits like `--test-name-pattern` to grep for certain tests, test durations, etc.

I did test various scenarios like throwing an error in a sync vs async test, timeouts, and errors in the sub-process output itself, and everything seems to work like before.