### PR TITLE
Add test expectations to web-platform-tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
         "node-qunit-phantomjs": "^2.1.1",
         "prettier": "^3.5.3",
         "qunitjs": "^1.23.1",
+        "smol-toml": "^1.4.1",
         "typescript": "^5.8.3"
     },
     "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       qunitjs:
         specifier: ^1.23.1
         version: 1.23.1
+      smol-toml:
+        specifier: ^1.4.1
+        version: 1.4.1
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -2875,6 +2878,10 @@ packages:
   slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
+
+  smol-toml@1.4.1:
+    resolution: {integrity: sha512-CxdwHXyYTONGHThDbq5XdwbFsuY4wlClRGejfE2NtwUtiHYsP1QtNsHb/hnj31jKYSchztJsaA8pSQoVzkfCFg==}
+    engines: {node: '>= 18'}
 
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
@@ -6635,6 +6642,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
+
+  smol-toml@1.4.1: {}
 
   source-map-support@0.5.13:
     dependencies:

--- a/src/test/web-platform-tests/README.md
+++ b/src/test/web-platform-tests/README.md
@@ -15,6 +15,18 @@ node --test --test-name-pattern="name of test" \
     ./src/test/web-platform-tests/run-all.js
 ```
 
+## Updating test expectations
+
+The test expectations (pass, fail, unstable, skip) are in the `manifests` folder. As you fix tests, you can either remove the `FAIL`/`UNSTABLE`/`skip` lines from the manifest files, or delete the file entirely if the whole thing is passing.
+
+To update all the manifest files at once based on the current test results, run:
+
+```sh
+GENERATE_MANIFESTS=1 pnpm run test-w3c
+```
+
+If the test results vary by Node version, you can add files in `overrides/node<version>` which will override the default.
+
 ## Updating the tests
 
 To update the tests, copy over the `IndexedDB` folder and remove `converted`:

--- a/src/test/web-platform-tests/convert.js
+++ b/src/test/web-platform-tests/convert.js
@@ -134,9 +134,6 @@ const outFolder = path.posix.join(__dirname, "converted");
             codeChunks.push(declareGlobalVars);
         }
 
-        if (testScript.includes("title=")) {
-            console.log("found!");
-        }
         const titleMatches = [
             ...testScript.matchAll(/\/\/\s*META:\s*title=(.+)$/gm),
         ];
@@ -170,12 +167,6 @@ const outFolder = path.posix.join(__dirname, "converted");
         codeChunks = codeChunks.map((chunk) => {
             return (
                 chunk
-                    // HACK: this test has to be disabled because we can't detect Proxies vs non-Proxies in JS
-                    .replaceAll(
-                        `invalid_key('proxy of an array', new Proxy([1, 2, 3], {}));`,
-                        "",
-                    )
-
                     // HACK: similar to above, this test runs in sloppy mode and assumes `this` is the global
                     .replaceAll(`this.saw =`, "saw =")
             );

--- a/src/test/web-platform-tests/converted/key_invalid.any.js
+++ b/src/test/web-platform-tests/converted/key_invalid.any.js
@@ -391,4 +391,4 @@ invalid_key('array indirectly contains self', recursive2);
 const recursive3 = [recursive];
 invalid_key('array member contains self', recursive3);
 
-
+invalid_key('proxy of an array', new Proxy([1, 2, 3], {}));

--- a/src/test/web-platform-tests/manifests/bindings-inject-keys-bypass.any.toml
+++ b/src/test/web-platform-tests/manifests/bindings-inject-keys-bypass.any.toml
@@ -1,0 +1,3 @@
+# Did not investigate in great detail.
+["Returning keys to script should bypass prototype setters"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/bindings-inject-values-bypass.any.toml
+++ b/src/test/web-platform-tests/manifests/bindings-inject-values-bypass.any.toml
@@ -1,0 +1,3 @@
+# Did not investigate in great detail.
+["Returning values to script should bypass prototype setters"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/blob-composite-blob-reads.any.toml
+++ b/src/test/web-platform-tests/manifests/blob-composite-blob-reads.any.toml
@@ -1,0 +1,6 @@
+# Node.js doesn't have Blob or File, and my simple mocks aren't good enough for these tests.
+["Composite Blob Handling: Many blobs: fetch-blob-url"]
+expectation = "FAIL"
+
+["Composite Blob Handling: Many blobs: direct"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/blob-contenttype.any.toml
+++ b/src/test/web-platform-tests/manifests/blob-contenttype.any.toml
@@ -1,0 +1,3 @@
+# Node.js doesn't have Blob or File, and my simple mocks aren't good enough for these tests.
+["Ensure that content type round trips when reading blob data"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/blob-valid-after-abort.any.toml
+++ b/src/test/web-platform-tests/manifests/blob-valid-after-abort.any.toml
@@ -1,0 +1,2 @@
+# Node.js doesn't have Blob or File, and my simple mocks aren't good enough for these tests.
+skip = true

--- a/src/test/web-platform-tests/manifests/blob-valid-after-deletion.any.toml
+++ b/src/test/web-platform-tests/manifests/blob-valid-after-deletion.any.toml
@@ -1,0 +1,3 @@
+# Node.js doesn't have Blob or File, and my simple mocks aren't good enough for these tests.
+["Blobs stay alive after their records are deleted."]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/blob-valid-before-commit.any.toml
+++ b/src/test/web-platform-tests/manifests/blob-valid-before-commit.any.toml
@@ -1,0 +1,3 @@
+# Node.js doesn't have Blob or File, and my simple mocks aren't good enough for these tests.
+["Blobs can be read back before their records are committed."]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/database-names-by-origin.toml
+++ b/src/test/web-platform-tests/manifests/database-names-by-origin.toml
@@ -1,0 +1,2 @@
+# relies on cross-iframe/cross-window communication which isn't relevant to us
+skip = true

--- a/src/test/web-platform-tests/manifests/event-dispatch-active-flag.any.toml
+++ b/src/test/web-platform-tests/manifests/event-dispatch-active-flag.any.toml
@@ -1,0 +1,3 @@
+# Maximum call stack size exceeded, possibly due to the promise resolution microtask not taking precedence when it
+# should (keep_alive not working).
+skip = true

--- a/src/test/web-platform-tests/manifests/file_support.sub.toml
+++ b/src/test/web-platform-tests/manifests/file_support.sub.toml
@@ -1,0 +1,3 @@
+# Relies on an <input type=file> which is hard for us to simulate
+["Saves and loads back File objects from IndexedDB"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/fire-error-event-exception.any.toml
+++ b/src/test/web-platform-tests/manifests/fire-error-event-exception.any.toml
@@ -1,0 +1,2 @@
+# These are pretty tricky. Would be nice to have them working.
+skip = true

--- a/src/test/web-platform-tests/manifests/fire-success-event-exception.any.toml
+++ b/src/test/web-platform-tests/manifests/fire-success-event-exception.any.toml
@@ -1,0 +1,2 @@
+# These are pretty tricky. Would be nice to have them working.
+skip = true

--- a/src/test/web-platform-tests/manifests/fire-upgradeneeded-event-exception.any.toml
+++ b/src/test/web-platform-tests/manifests/fire-upgradeneeded-event-exception.any.toml
@@ -1,0 +1,2 @@
+# These are pretty tricky. Would be nice to have them working.
+skip = true

--- a/src/test/web-platform-tests/manifests/get-databases.any.toml
+++ b/src/test/web-platform-tests/manifests/get-databases.any.toml
@@ -1,0 +1,6 @@
+# Mostly works, except the last test which is edge cases
+["Enumerate multiple databases."]
+expectation = "FAIL"
+
+["Ensure that databases() doesn't pick up changes that haven't commited."]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idb-explicit-commit-throw.any.toml
+++ b/src/test/web-platform-tests/manifests/idb-explicit-commit-throw.any.toml
@@ -1,0 +1,3 @@
+# Not sure how to do this weird error silencing in Node.js.
+["Any errors in callbacks that run after an explicit commit will not stop the commit from being processed."]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idb-explicit-commit.any.toml
+++ b/src/test/web-platform-tests/manifests/idb-explicit-commit.any.toml
@@ -1,0 +1,2 @@
+# Mostly works, but keepAlive results in an infinite loop
+skip = true

--- a/src/test/web-platform-tests/manifests/idb-partitioned-basic.sub.toml
+++ b/src/test/web-platform-tests/manifests/idb-partitioned-basic.sub.toml
@@ -1,0 +1,3 @@
+# relies on cross-iframe/cross-window communication which isn't relevant to us
+["Simple test for partitioned IndexedDB"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idb-partitioned-coverage.sub.toml
+++ b/src/test/web-platform-tests/manifests/idb-partitioned-coverage.sub.toml
@@ -1,0 +1,2 @@
+# relies on cross-iframe/cross-window communication which isn't relevant to us
+skip = true

--- a/src/test/web-platform-tests/manifests/idb-partitioned-persistence.sub.toml
+++ b/src/test/web-platform-tests/manifests/idb-partitioned-persistence.sub.toml
@@ -1,0 +1,3 @@
+# relies on cross-iframe/cross-window communication which isn't relevant to us
+["Persistence test for partitioned IndexedDB"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idb_webworkers.toml
+++ b/src/test/web-platform-tests/manifests/idb_webworkers.toml
@@ -1,0 +1,2 @@
+# No Web Worker in Node.js.
+skip = true

--- a/src/test/web-platform-tests/manifests/idbcursor-advance-exception-order.any.toml
+++ b/src/test/web-platform-tests/manifests/idbcursor-advance-exception-order.any.toml
@@ -1,0 +1,3 @@
+# these tests rely on the precise ordering of exceptions, which we currently fail sometimes
+["IDBCursor.advance exception order: TransactionInactiveError vs. InvalidStateError #2"]
+expectation = "UNSTABLE"

--- a/src/test/web-platform-tests/manifests/idbcursor-continue-exception-order.any.toml
+++ b/src/test/web-platform-tests/manifests/idbcursor-continue-exception-order.any.toml
@@ -1,0 +1,6 @@
+# Usually works, but there is a race condition. Sometimes the setTimeout runs before the transaction commits.
+["IDBCursor.continue exception order: TransactionInactiveError vs. DataError"]
+expectation = "UNSTABLE"
+
+["IDBCursor.continue exception order: TransactionInactiveError vs. InvalidStateError"]
+expectation = "UNSTABLE"

--- a/src/test/web-platform-tests/manifests/idbcursor-delete-exception-order.any.toml
+++ b/src/test/web-platform-tests/manifests/idbcursor-delete-exception-order.any.toml
@@ -1,0 +1,3 @@
+# Usually works, but there is a race condition. Sometimes the setTimeout runs before the transaction commits.
+["IDBCursor.delete exception order: TransactionInactiveError vs. ReadOnlyError"]
+expectation = "UNSTABLE"

--- a/src/test/web-platform-tests/manifests/idbcursor-update-exception-order.any.toml
+++ b/src/test/web-platform-tests/manifests/idbcursor-update-exception-order.any.toml
@@ -1,0 +1,3 @@
+# Usually works, but there is a race condition. Sometimes the setTimeout runs before the transaction commits.
+["IDBCursor.update exception order: TransactionInactiveError vs. ReadOnlyError"]
+expectation = "UNSTABLE"

--- a/src/test/web-platform-tests/manifests/idbdatabase-createObjectStore-exception-order.any.toml
+++ b/src/test/web-platform-tests/manifests/idbdatabase-createObjectStore-exception-order.any.toml
@@ -1,0 +1,3 @@
+# these tests rely on the precise ordering of exceptions, which we currently fail
+["IDBDatabase.createObjectStore exception order: TransactionInactiveError vs. SyntaxError"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbdatabase-deleteObjectStore-exception-order.any.toml
+++ b/src/test/web-platform-tests/manifests/idbdatabase-deleteObjectStore-exception-order.any.toml
@@ -1,0 +1,3 @@
+# these tests rely on the precise ordering of exceptions, which we currently fail
+["IDBDatabase.deleteObjectStore exception order: TransactionInactiveError vs. NotFoundError"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbdatabase-transaction-exception-order.any.toml
+++ b/src/test/web-platform-tests/manifests/idbdatabase-transaction-exception-order.any.toml
@@ -1,0 +1,3 @@
+# these tests rely on the precise ordering of exceptions, which we currently fail
+["IDBDatabase.transaction throws exception on invalid mode"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbfactory-databases-opaque-origin.toml
+++ b/src/test/web-platform-tests/manifests/idbfactory-databases-opaque-origin.toml
@@ -1,0 +1,12 @@
+# Did not investigate in great detail.
+["IDBFactory.databases() in non-sandboxed iframe should not reject"]
+expectation = "FAIL"
+
+["IDBFactory.databases() in sandboxed iframe should reject"]
+expectation = "FAIL"
+
+["IDBFactory.databases() in data URL dedicated worker should throw SecurityError"]
+expectation = "FAIL"
+
+["IDBFactory.databases() in data URL shared worker should throw SecurityError"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbfactory-deleteDatabase-opaque-origin.toml
+++ b/src/test/web-platform-tests/manifests/idbfactory-deleteDatabase-opaque-origin.toml
@@ -1,0 +1,12 @@
+# No iframe in Node.js.
+["IDBFactory.deleteDatabase() in non-sandboxed iframe should not throw"]
+expectation = "FAIL"
+
+["IDBFactory.deleteDatabase() in sandboxed iframe should throw SecurityError"]
+expectation = "FAIL"
+
+["IDBFactory.deleteDatabase() in data URL dedicated worker should throw SecurityError"]
+expectation = "FAIL"
+
+["IDBFactory.deleteDatabase() in data URL shared worker should throw SecurityError"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbfactory-open-opaque-origin.toml
+++ b/src/test/web-platform-tests/manifests/idbfactory-open-opaque-origin.toml
@@ -1,0 +1,12 @@
+# No iframe in Node.js.
+["IDBFactory.open() in non-sandboxed iframe should not throw"]
+expectation = "FAIL"
+
+["IDBFactory.open() in sandboxed iframe should throw SecurityError"]
+expectation = "FAIL"
+
+["IDBFactory.open() in data URL dedicated workers should throw SecurityError"]
+expectation = "FAIL"
+
+["IDBFactory.open() in data URL shared workers should throw SecurityError"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbfactory-origin-isolation.toml
+++ b/src/test/web-platform-tests/manifests/idbfactory-origin-isolation.toml
@@ -1,0 +1,2 @@
+# Doesn't seem relevant to a node.js test (cross-origin isolation)
+skip = true

--- a/src/test/web-platform-tests/manifests/idbfactory_open.any.toml
+++ b/src/test/web-platform-tests/manifests/idbfactory_open.any.toml
@@ -1,0 +1,3 @@
+# Hangs because `dbname` is the same for all the async tests. If `dbname` was different for each async test, it
+# would work.
+skip = true

--- a/src/test/web-platform-tests/manifests/idbindex-cross-realm-methods.toml
+++ b/src/test/web-platform-tests/manifests/idbindex-cross-realm-methods.toml
@@ -1,0 +1,2 @@
+# relies on cross-iframe/cross-window communication which isn't relevant to us
+skip = true

--- a/src/test/web-platform-tests/manifests/idbindex-rename-abort.any.toml
+++ b/src/test/web-platform-tests/manifests/idbindex-rename-abort.any.toml
@@ -1,0 +1,3 @@
+# Mostly works, but subtlely wrong behavior when renaming a newly-created index/store and then aborting the upgrade
+# transaction (this has roughly 0 real world impact, but could be indicative of other problems in fake-indexeddb).
+skip = true

--- a/src/test/web-platform-tests/manifests/idbindex_get.any.toml
+++ b/src/test/web-platform-tests/manifests/idbindex_get.any.toml
@@ -1,0 +1,7 @@
+# Fails because FDBTransaction._abort synchronously sends out error events to open requests, when it should be
+# asynchronous according to the spec. Making it asynchronous causes other tests to fail though. Need to be more
+# careful about making sure other asynchronous things are actually asynchronous, and also "asynchronous" doesn't
+# just mean "wrap in setImmediate", in this context it means to wait until prior requests are complete and then
+# execute.
+["get() throws InvalidStateError on index deleted by aborted upgrade"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbindex_getKey.any.toml
+++ b/src/test/web-platform-tests/manifests/idbindex_getKey.any.toml
@@ -1,0 +1,7 @@
+# Fails because FDBTransaction._abort synchronously sends out error events to open requests, when it should be
+# asynchronous according to the spec. Making it asynchronous causes other tests to fail though. Need to be more
+# careful about making sure other asynchronous things are actually asynchronous, and also "asynchronous" doesn't
+# just mean "wrap in setImmediate", in this context it means to wait until prior requests are complete and then
+# execute.
+["getKey() throws InvalidStateError on index deleted by aborted upgrade"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbindex_openCursor.any.toml
+++ b/src/test/web-platform-tests/manifests/idbindex_openCursor.any.toml
@@ -1,0 +1,7 @@
+# Fails because FDBTransaction._abort synchronously sends out error events to open requests, when it should be
+# asynchronous according to the spec. Making it asynchronous causes other tests to fail though. Need to be more
+# careful about making sure other asynchronous things are actually asynchronous, and also "asynchronous" doesn't
+# just mean "wrap in setImmediate", in this context it means to wait until prior requests are complete and then
+# execute.
+["If the index is deleted by an aborted upgrade, throw InvalidStateError"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbindex_openKeyCursor.any.toml
+++ b/src/test/web-platform-tests/manifests/idbindex_openKeyCursor.any.toml
@@ -1,0 +1,7 @@
+# Fails because FDBTransaction._abort synchronously sends out error events to open requests, when it should be
+# asynchronous according to the spec. Making it asynchronous causes other tests to fail though. Need to be more
+# careful about making sure other asynchronous things are actually asynchronous, and also "asynchronous" doesn't
+# just mean "wrap in setImmediate", in this context it means to wait until prior requests are complete and then
+# execute.
+["Throw InvalidStateError on index deleted by aborted upgrade"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbobjectstore-cross-realm-methods.toml
+++ b/src/test/web-platform-tests/manifests/idbobjectstore-cross-realm-methods.toml
@@ -1,0 +1,33 @@
+# relies on cross-iframe/cross-window communication which isn't relevant to us
+["Cross-realm IDBObjectStore::put() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::add() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::delete() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::clear() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::get() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::getKey() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::getAll() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::getAllKeys() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::count() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::openCursor() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::openKeyCursor() method from detached <iframe> works as expected"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbobjectstore-rename-abort.any.toml
+++ b/src/test/web-platform-tests/manifests/idbobjectstore-rename-abort.any.toml
@@ -1,0 +1,3 @@
+# Mostly works, but subtlely wrong behavior when renaming a newly-created index/store and then aborting the upgrade
+# transaction (this has roughly 0 real world impact, but could be indicative of other problems in fake-indexeddb).
+skip = true

--- a/src/test/web-platform-tests/manifests/idbrequest-onupgradeneeded.any.toml
+++ b/src/test/web-platform-tests/manifests/idbrequest-onupgradeneeded.any.toml
@@ -1,0 +1,2 @@
+# Half works, and I don't care enough to investigate further right now.
+skip = true

--- a/src/test/web-platform-tests/manifests/idbtransaction_abort.any.toml
+++ b/src/test/web-platform-tests/manifests/idbtransaction_abort.any.toml
@@ -1,0 +1,3 @@
+# Flakey test - sometimes passes, sometimes fails, needs investigation
+["Abort during auto-committing should throw InvalidStateError."]
+expectation = "UNSTABLE"

--- a/src/test/web-platform-tests/manifests/key_invalid.any.toml
+++ b/src/test/web-platform-tests/manifests/key_invalid.any.toml
@@ -1,0 +1,3 @@
+# fails because we can't detect Proxies vs non-Proxies in JavaScript
+["Invalid key - proxy of an array"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/nested-cloning-basic.any.toml
+++ b/src/test/web-platform-tests/manifests/nested-cloning-basic.any.toml
@@ -1,0 +1,6 @@
+# Node.js doesn't have Blob or File, and my simple mocks aren't good enough for these tests.
+["small typed array"]
+expectation = "FAIL"
+
+[blob]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/nested-cloning-large-multiple.any.toml
+++ b/src/test/web-platform-tests/manifests/nested-cloning-large-multiple.any.toml
@@ -1,0 +1,6 @@
+# Node.js doesn't have Blob or File, and my simple mocks aren't good enough for these tests.
+["multiple requests of objects with blobs and large typed arrays"]
+expectation = "FAIL"
+
+["multiple requests of objects with blobs and large typed arrays with key generator"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/nested-cloning-large.any.toml
+++ b/src/test/web-platform-tests/manifests/nested-cloning-large.any.toml
@@ -1,0 +1,21 @@
+# Node.js doesn't have Blob or File, and my simple mocks aren't good enough for these tests.
+["large typed array"]
+expectation = "FAIL"
+
+["blob with large typed array"]
+expectation = "FAIL"
+
+["blob with large typed array with key generator"]
+expectation = "FAIL"
+
+["array of blobs and large typed arrays"]
+expectation = "FAIL"
+
+["array of blobs and large typed arrays with key generator"]
+expectation = "FAIL"
+
+["object with blobs and large typed arrays"]
+expectation = "FAIL"
+
+["object with blobs and large typed arrays with key generator"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/nested-cloning-small.any.toml
+++ b/src/test/web-platform-tests/manifests/nested-cloning-small.any.toml
@@ -1,0 +1,18 @@
+# Node.js doesn't have Blob or File, and my simple mocks aren't good enough for these tests.
+["blob with small typed array"]
+expectation = "FAIL"
+
+["blob with small typed array with key generator"]
+expectation = "FAIL"
+
+["blob array"]
+expectation = "FAIL"
+
+["blob array with key generator"]
+expectation = "FAIL"
+
+["array of blobs and small typed arrays"]
+expectation = "FAIL"
+
+["array of blobs and small typed arrays with key generator"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/open-request-queue.any.toml
+++ b/src/test/web-platform-tests/manifests/open-request-queue.any.toml
@@ -1,0 +1,2 @@
+# All kinds of fucked up.
+skip = true

--- a/src/test/web-platform-tests/manifests/overrides/node18/idb-binary-key-roundtrip.any.toml
+++ b/src/test/web-platform-tests/manifests/overrides/node18/idb-binary-key-roundtrip.any.toml
@@ -1,0 +1,3 @@
+# Fails in Node <24 due to lack of Float16Array
+["Binary keys can be supplied using the view type Float16Array"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/overrides/node18/idb_binary_key_conversion.any.toml
+++ b/src/test/web-platform-tests/manifests/overrides/node18/idb_binary_key_conversion.any.toml
@@ -1,0 +1,3 @@
+# This breaks in Node <22 because of lack of support for `ArrayBuffer.prototype.detached`
+["Empty ArrayBuffer"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/overrides/node20/idb-binary-key-roundtrip.any.toml
+++ b/src/test/web-platform-tests/manifests/overrides/node20/idb-binary-key-roundtrip.any.toml
@@ -1,0 +1,3 @@
+# Fails in Node <24 due to lack of Float16Array
+["Binary keys can be supplied using the view type Float16Array"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/overrides/node20/idb_binary_key_conversion.any.toml
+++ b/src/test/web-platform-tests/manifests/overrides/node20/idb_binary_key_conversion.any.toml
@@ -1,0 +1,3 @@
+# This breaks in Node <22 because of lack of support for `ArrayBuffer.prototype.detached`
+["Empty ArrayBuffer"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/overrides/node22/idb-binary-key-roundtrip.any.toml
+++ b/src/test/web-platform-tests/manifests/overrides/node22/idb-binary-key-roundtrip.any.toml
@@ -1,0 +1,3 @@
+# Fails in Node <24 due to lack of Float16Array
+["Binary keys can be supplied using the view type Float16Array"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/ready-state-destroyed-execution-context.toml
+++ b/src/test/web-platform-tests/manifests/ready-state-destroyed-execution-context.toml
@@ -1,0 +1,3 @@
+# relies on cross-iframe/cross-window communication which isn't relevant to us
+["readyState accessor is valid after execution context is destroyed"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/request-event-ordering-large-mixed-with-small-values.any.toml
+++ b/src/test/web-platform-tests/manifests/request-event-ordering-large-mixed-with-small-values.any.toml
@@ -1,0 +1,3 @@
+# Did not investigate in great detail.
+["large values mixed with small values"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/request-event-ordering-large-then-small-values.any.toml
+++ b/src/test/web-platform-tests/manifests/request-event-ordering-large-then-small-values.any.toml
@@ -1,0 +1,3 @@
+# Did not investigate in great detail.
+["large value followed by small values"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/request-event-ordering-small-values.any.toml
+++ b/src/test/web-platform-tests/manifests/request-event-ordering-small-values.any.toml
@@ -1,0 +1,3 @@
+# Did not investigate in great detail.
+["small values"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/resources/cross-origin-helper-frame.toml
+++ b/src/test/web-platform-tests/manifests/resources/cross-origin-helper-frame.toml
@@ -1,0 +1,2 @@
+# relies on cross-iframe/cross-window communication which isn't relevant to us
+skip = true

--- a/src/test/web-platform-tests/manifests/resources/idb-partitioned-basic-iframe.toml
+++ b/src/test/web-platform-tests/manifests/resources/idb-partitioned-basic-iframe.toml
@@ -1,0 +1,2 @@
+# relies on cross-iframe/cross-window communication which isn't relevant to us
+skip = true

--- a/src/test/web-platform-tests/manifests/resources/idb-partitioned-persistence-iframe.toml
+++ b/src/test/web-platform-tests/manifests/resources/idb-partitioned-persistence-iframe.toml
@@ -1,0 +1,2 @@
+# relies on cross-iframe/cross-window communication which isn't relevant to us
+skip = true

--- a/src/test/web-platform-tests/manifests/resources/idbfactory-origin-isolation-iframe.toml
+++ b/src/test/web-platform-tests/manifests/resources/idbfactory-origin-isolation-iframe.toml
@@ -1,0 +1,2 @@
+# Doesn't seem relevant to a node.js test (cross-origin isolation)
+skip = true

--- a/src/test/web-platform-tests/manifests/serialize-sharedarraybuffer-throws.https.toml
+++ b/src/test/web-platform-tests/manifests/serialize-sharedarraybuffer-throws.https.toml
@@ -1,0 +1,3 @@
+# Doesn't seem relevant to a node.js test (cross-origin isolation)
+["Anonymous test #1"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/storage-buckets.https.any.toml
+++ b/src/test/web-platform-tests/manifests/storage-buckets.https.any.toml
@@ -1,0 +1,6 @@
+# we do not currently support `navigator.storageBuckets`
+["Basic test that buckets create independent databases."]
+expectation = "FAIL"
+
+["Tests trying to use indexedDB in a deleted bucket."]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/structured-clone-transaction-state.any.toml
+++ b/src/test/web-platform-tests/manifests/structured-clone-transaction-state.any.toml
@@ -1,0 +1,9 @@
+# these test our ability to do a structured clone on various DOM types like DOMRect which we don't support
+["Transaction inactive during structured clone in IDBObjectStore.add()"]
+expectation = "FAIL"
+
+["Transaction inactive during structured clone in IDBObjectStore.put()"]
+expectation = "FAIL"
+
+["Transaction inactive during structured clone in IDBCursor.update()"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/structured-clone.any.toml
+++ b/src/test/web-platform-tests/manifests/structured-clone.any.toml
@@ -1,0 +1,2 @@
+# these test our ability to do a structured clone on various DOM types like DOMRect which we don't support
+skip = true

--- a/src/test/web-platform-tests/manifests/transaction-abort-generator-revert.any.toml
+++ b/src/test/web-platform-tests/manifests/transaction-abort-generator-revert.any.toml
@@ -1,0 +1,2 @@
+# Did not investigate in great detail.
+skip = true

--- a/src/test/web-platform-tests/manifests/transaction-abort-index-metadata-revert.any.toml
+++ b/src/test/web-platform-tests/manifests/transaction-abort-index-metadata-revert.any.toml
@@ -1,0 +1,3 @@
+# Mostly works, but subtlely wrong behavior when renaming a newly-created index/store and then aborting the upgrade
+# transaction (this has roughly 0 real world impact, but could be indicative of other problems in fake-indexeddb).
+skip = true

--- a/src/test/web-platform-tests/manifests/transaction-abort-multiple-metadata-revert.any.toml
+++ b/src/test/web-platform-tests/manifests/transaction-abort-multiple-metadata-revert.any.toml
@@ -1,0 +1,3 @@
+# Mostly works, but subtlely wrong behavior when renaming a newly-created index/store and then aborting the upgrade
+# transaction (this has roughly 0 real world impact, but could be indicative of other problems in fake-indexeddb).
+skip = true

--- a/src/test/web-platform-tests/manifests/transaction-abort-object-store-metadata-revert.any.toml
+++ b/src/test/web-platform-tests/manifests/transaction-abort-object-store-metadata-revert.any.toml
@@ -1,0 +1,3 @@
+# Mostly works, but subtlely wrong behavior when renaming a newly-created index/store and then aborting the upgrade
+# transaction (this has roughly 0 real world impact, but could be indicative of other problems in fake-indexeddb).
+skip = true

--- a/src/test/web-platform-tests/manifests/transaction-abort-request-error.any.toml
+++ b/src/test/web-platform-tests/manifests/transaction-abort-request-error.any.toml
@@ -1,0 +1,4 @@
+# Fails because `onerror` is never called since it is set after the abort call and the events on the request are
+# triggered synchronously. Not sure how to reconcile this with the spec. Same issue affected some other test too, I
+# think.
+skip = true

--- a/src/test/web-platform-tests/manifests/transaction-deactivation-timing.any.toml
+++ b/src/test/web-platform-tests/manifests/transaction-deactivation-timing.any.toml
@@ -1,0 +1,3 @@
+# Maximum call stack size exceeded, possibly due to the promise resolution microtask not taking precedence when it
+# should (keep_alive not working).
+skip = true

--- a/src/test/web-platform-tests/manifests/transaction-lifetime-empty.any.toml
+++ b/src/test/web-platform-tests/manifests/transaction-lifetime-empty.any.toml
@@ -1,0 +1,2 @@
+# Did not investigate in great detail.
+skip = true

--- a/src/test/web-platform-tests/manifests/transaction-lifetime.any.toml
+++ b/src/test/web-platform-tests/manifests/transaction-lifetime.any.toml
@@ -1,0 +1,2 @@
+# test hangs, needs further investigation
+skip = true

--- a/src/test/web-platform-tests/manifests/transaction-relaxed-durability.any.toml
+++ b/src/test/web-platform-tests/manifests/transaction-relaxed-durability.any.toml
@@ -1,0 +1,18 @@
+# fakeIndexedDB does not currently support relaxed durability or durability options
+["Committed data can be read back out: case 0"]
+expectation = "FAIL"
+
+["Committed data can be read back out: case 1"]
+expectation = "FAIL"
+
+["Committed data can be read back out: case 2"]
+expectation = "FAIL"
+
+["Committed data can be read back out: case 3"]
+expectation = "FAIL"
+
+["Committed data can be read back out: case 4"]
+expectation = "FAIL"
+
+["Invalid durability option throws a TypeError"]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/transaction-scheduling-within-database.any.toml
+++ b/src/test/web-platform-tests/manifests/transaction-scheduling-within-database.any.toml
@@ -1,0 +1,3 @@
+# async timing test which we currently fail:
+# "Check that read-only transactions within a database can run in parallel"
+skip = true

--- a/src/test/web-platform-tests/manifests/upgrade-transaction-deactivation-timing.any.toml
+++ b/src/test/web-platform-tests/manifests/upgrade-transaction-deactivation-timing.any.toml
@@ -1,0 +1,3 @@
+# Maximum call stack size exceeded, possibly due to the promise resolution microtask not taking precedence when it
+# should (keep_alive not working).
+skip = true

--- a/src/test/web-platform-tests/manifests/upgrade-transaction-lifecycle-backend-aborted.any.toml
+++ b/src/test/web-platform-tests/manifests/upgrade-transaction-lifecycle-backend-aborted.any.toml
@@ -1,0 +1,2 @@
+# Did not investigate in great detail.
+skip = true

--- a/src/test/web-platform-tests/manifests/upgrade-transaction-lifecycle-user-aborted.any.toml
+++ b/src/test/web-platform-tests/manifests/upgrade-transaction-lifecycle-user-aborted.any.toml
@@ -1,0 +1,2 @@
+# Did not investigate in great detail.
+skip = true

--- a/src/test/web-platform-tests/run-all.js
+++ b/src/test/web-platform-tests/run-all.js
@@ -1,214 +1,71 @@
-/* global console */
+/* global console, process */
 
 import { test } from "node:test";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import path from "node:path";
+import * as fs from "node:fs";
+import { parse, stringify } from "smol-toml";
 import { glob } from "glob";
 
 const execAsync = promisify(exec);
 
+const generateManifests = process.env.GENERATE_MANIFESTS;
+
 const __dirname = "src/test/web-platform-tests";
 const testFolder = path.join(__dirname, "converted");
+const manifestsFolder = path.join(__dirname, "manifests");
 
-/* global process */
 const nodeMajorVersion = parseInt(process.version.substring(1).split(".")[0]);
 
-let skipped = new Set();
+const filenames = glob.sync("/**/*.js", { root: testFolder });
 
-const skip = [
-    // Maximum call stack size exceeded, possibly due to the promise resolution microtask not taking precedence when it
-    // should (keep_alive not working).
-    "event-dispatch-active-flag.any.js",
-    "transaction-deactivation-timing.any.js",
-    "upgrade-transaction-deactivation-timing.any.js",
-
-    // These are pretty tricky. Would be nice to have them working.
-    "fire-error-event-exception.any.js",
-    "fire-success-event-exception.any.js",
-    "fire-upgradeneeded-event-exception.any.js",
-
-    // Mostly works, except the last test which is edge cases
-    "get-databases.any.js",
-
-    // No Web Worker in Node.js.
-    "idb_webworkers.js",
-
-    // Mostly works, but Node.js doesn't support trailing commas in function parameters, and there's some other subtle
-    // issues too.
-    "idb-binary-key-roundtrip.any.js",
-
-    // Mostly works, but keepAlive results in an infinite loop
-    "idb-explicit-commit.any.js",
-
-    // Not sure how to do this weird error silencing in Node.js.
-    "idb-explicit-commit-throw.any.js",
-
-    // Usually works, but there is a race condition. Sometimes the setTimeout runs before the transaction commits.
-    "idbcursor-continue-exception-order.any.js",
-    "idbcursor-delete-exception-order.any.js",
-    "idbcursor-update-exception-order.any.js",
-    "idbobjectstore-add-put-exception-order.any.js",
-    "idbobjectstore-clear-exception-order.any.js",
-    "idbobjectstore-delete-exception-order.any.js",
-    "idbobjectstore-deleteIndex-exception-order.any.js",
-    "idbobjectstore-query-exception-order.any.js",
-
-    // No iframe in Node.js.
-    "idbfactory-deleteDatabase-opaque-origin.js",
-    "idbfactory-open-opaque-origin.js",
-
-    // Hangs because `dbname` is the same for all the async tests. If `dbname` was different for each async test, it
-    // would work.
-    "idbfactory_open.any.js",
-
-    // Fails because FDBTransaction._abort synchronously sends out error events to open requests, when it should be
-    // asynchronous according to the spec. Making it asynchronous causes other tests to fail though. Need to be more
-    // careful about making sure other asynchronous things are actually asynchronous, and also "asynchronous" doesn't
-    // just mean "wrap in setImmediate", in this context it means to wait until prior requests are complete and then
-    // execute.
-    "idbindex_get.any.js",
-    "idbindex_getKey.any.js",
-    "idbindex_openCursor.any.js",
-    "idbindex_openKeyCursor.any.js",
-
-    // Mostly works, but subtlely wrong behavior when renaming a newly-created index/store and then aborting the upgrade
-    // transaction (this has roughly 0 real world impact, but could be indicative of other problems in fake-indexeddb).
-    "idbindex-rename-abort.any.js",
-    "idbobjectstore-rename-abort.any.js",
-    "transaction-abort-index-metadata-revert.any.js",
-    "transaction-abort-multiple-metadata-revert.any.js",
-    "transaction-abort-object-store-metadata-revert.any.js",
-
-    // Half works, and I don't care enough to investigate further right now.
-    "idbrequest-onupgradeneeded.any.js",
-
-    // db2.close() sets _closePending flag, and then that's checked in runVersionchangeTransaction resulting in an
-    // AbortError. Based on https://w3c.github.io/IndexedDB/#opening this seems corret, so I'm not sure why this test is
-    // supposed to work.
-    "idbtransaction_objectStoreNames.any.js",
-
-    // Node.js doesn't have Blob or File, and my simple mocks aren't good enough for these tests.
-    "blob-valid-before-commit.any.js",
-    "blob-valid-after-deletion.any.js",
-    "blob-delete-objectstore-db.any.js",
-    "blob-contenttype.any.js",
-    "blob-composite-blob-reads.any.js",
-    "nested-cloning-small.any.js",
-    "nested-cloning-large.any.js",
-    "nested-cloning-large-multiple.any.js",
-    "nested-cloning-basic.any.js",
-    "blob-valid-after-abort.any.js",
-
-    // All kinds of fucked up.
-    "open-request-queue.any.js",
-
-    // Flakey test - sometimes passes, sometimes fails, needs investigation
-    "idbtransaction_abort.any.js",
-
-    // Did not investigate in great detail.
-    "bindings-inject-keys-bypass.any.js",
-    "bindings-inject-values-bypass.any.js",
-    "idbfactory-databases-opaque-origin.js",
-    "request-event-ordering-large-mixed-with-small-values.any.js",
-    "request-event-ordering-large-then-small-values.any.js",
-    "request-event-ordering-large-values.any.js",
-    "request-event-ordering-small-values.any.js",
-    "transaction-abort-generator-revert.any.js",
-    "transaction-lifetime-empty.any.js",
-    "upgrade-transaction-lifecycle-backend-aborted.any.js",
-    "upgrade-transaction-lifecycle-user-aborted.any.js",
-
-    // Fails because `onerror` is never called since it is set after the abort call and the events on the request are
-    // triggered synchronously. Not sure how to reconcile this with the spec. Same issue affected some other test too, I
-    // think.
-    "transaction-abort-request-error.any.js",
-
-    // Relies on an <input type=file> which is hard for us to simulate
-    "file_support.sub.js",
-
-    // Doesn't seem relevant to a node.js test (cross-origin isolation)
-    "resources/idbfactory-origin-isolation-iframe.js",
-    "idbfactory-origin-isolation.js",
-    "serialize-sharedarraybuffer-throws.https.js",
-
-    // fakeIndexedDB does not currently support relaxed durability or durability options
-    "transaction-relaxed-durability.any.js",
-
-    // these test our ability to do a structured clone on various DOM types like DOMRect which we don't support
-    "structured-clone.any.js",
-    "structured-clone-transaction-state.any.js",
-
-    // these tests rely on the precise ordering of exceptions, which we currently fail
-    "idbcursor-advance-exception-order.any.js",
-    "idbdatabase-createObjectStore-exception-order.any.js",
-    "idbdatabase-deleteObjectStore-exception-order.any.js",
-    "idbdatabase-transaction-exception-order.any.js",
-
-    // async timing test which we currently fail:
-    // "Check that read-only transactions within a database can run in parallel"
-    "transaction-scheduling-within-database.any.js",
-
-    // relies on cross-iframe/cross-window communication which isn't relevant to us
-    "database-names-by-origin.js",
-    "idbindex-cross-realm-methods.js",
-    "idbobjectstore-cross-realm-methods.js",
-    "idb-partitioned-basic.sub.js",
-    "idb-partitioned-coverage.sub.js",
-    "idb-partitioned-persistence.sub.js",
-    "ready-state-destroyed-execution-context.js",
-    "resources/cross-origin-helper-frame.js",
-    "resources/idb-partitioned-basic-iframe.js",
-    "resources/idb-partitioned-coverage-iframe.js",
-    "resources/idb-partitioned-persistence-iframe.js",
-
-    // we do not currently support `navigator.storageBuckets`
-    "storage-buckets.https.any.js",
-
-    // test hangs, needs further investigation
-    "transaction-lifetime.any.js",
-
-    // These break in Node <20 because of lack of support for `ArrayBuffer.prototype.detached`
-    ...(nodeMajorVersion < 22
-        ? [
-              "idb_binary_key_conversion.any.js",
-              "idb-binary-key-detached.any.js",
-              "idbindex_getAll.any.js",
-              "idbindex_getAllKeys.any.js",
-              "idbindex_getAllKeys-options.tentative.any.js",
-              "idbindex_getAll-options.tentative.any.js",
-              "idbindex_getAllRecords.tentative.any.js",
-              "idbobjectstore_getAll.any.js",
-              "idbobjectstore_getAllKeys.any.js",
-              "idbobjectstore_getAllKeys-options.tentative.any.js",
-              "idbobjectstore_getAll-options.tentative.any.js",
-              "idbobjectstore_getAllRecords.tentative.any.js",
-          ]
-        : []),
-];
-
-if (new Set(skip).size !== skip.length) {
-    const skipCounts = new Map();
-    for (const test of skip) {
-        skipCounts.set(test, 1 + (skipCounts.get(test) || 0));
+function parseManifest(manifestFilename) {
+    const text =
+        fs.existsSync(manifestFilename) &&
+        fs.readFileSync(manifestFilename, "utf-8");
+    if (!text) {
+        return;
     }
-    throw new Error(
-        "Duplicates exist in skip array, please remove them: " +
-            [...skipCounts.entries()]
-                .filter((_) => _[1] > 1)
-                .map((_) => _[0])
-                .join(", "),
+    const contents = parse(text);
+    // we want to preserve comments, and smol-toml has no way to extract them
+    const comments = [...text.matchAll(/(?:^|\n)#([^#\n]+)/g)].map((_) => _[1]);
+    return { contents, comments };
+}
+
+function stringifyManifest(generatedManifest, comments) {
+    return (
+        (comments ? comments.map((_) => `#${_}\n`).join("") : "") +
+        stringify(generatedManifest)
     );
 }
 
-const filenames = glob.sync("/**/*.js", { root: testFolder });
+let numExpectedFailures = 0;
+let numUnstableTests = 0;
+
 for (const absFilename of filenames) {
     const filename = path.relative(testFolder, absFilename);
-    const shouldSkip = skip.includes(filename);
-    if (shouldSkip) {
-        skipped.add(filename);
+
+    const generatedManifest = {};
+
+    const manifestBasename = filename.replace(/\.js$/, ".toml");
+    const manifestFilename = path.join(manifestsFolder, manifestBasename);
+    // if any tests are failing only in older node versions, they go in the override
+    const overrideManifestFilename = path.join(
+        manifestsFolder,
+        `overrides/node${nodeMajorVersion}`,
+        manifestBasename,
+    );
+    const expectedManifest = fs.existsSync(overrideManifestFilename)
+        ? parseManifest(overrideManifestFilename)
+        : parseManifest(manifestFilename);
+    const skip = expectedManifest?.contents?.skip;
+
+    if (skip) {
+        generatedManifest.skip = true;
     }
-    await test(filename, { skip: shouldSkip }, async (t) => {
+
+    await test(filename, { skip }, async (t) => {
         const { stdout, stderr } = await execAsync(`node ${filename}`, {
             cwd: testFolder,
             encoding: "utf-8",
@@ -216,7 +73,7 @@ for (const absFilename of filenames) {
         if (stderr) {
             console.error(stderr);
         }
-        const results = Object.create(null);
+        const results = {};
         const resultLines = stdout
             .split("\n")
             .filter((_) => _.includes("testResult"))
@@ -232,18 +89,66 @@ for (const absFilename of filenames) {
         if (!Object.keys(results).length) {
             throw new Error("Did not receive any test results from test");
         }
-        for (const [name, result] of Object.entries(results)) {
-            await t.test(name, () => {
-                if (!result.passed) {
-                    throw new Error(result.error);
+
+        try {
+            for (const [name, result] of Object.entries(results)) {
+                const expectation =
+                    expectedManifest?.contents?.[name]?.expectation;
+                const friendlyText =
+                    expectation === "FAIL"
+                        ? " (expected failure)"
+                        : expectation === "UNSTABLE"
+                          ? " (expected unstable)"
+                          : "";
+                await t.test(`${name}${friendlyText}`, () => {
+                    if (expectation === "UNSTABLE") {
+                        // if the test is unstable, make no assumptions about the pass/fail state and move on
+                        generatedManifest[name] = {
+                            expectation: "UNSTABLE",
+                        };
+                        numUnstableTests += 1;
+                    } else if (result.passed) {
+                        if (expectation === "FAIL") {
+                            throw new Error(
+                                "Expected test to fail, but it passed",
+                            );
+                        }
+                    } else {
+                        generatedManifest[name] = {
+                            expectation: "FAIL",
+                        };
+                        if (expectation === "FAIL") {
+                            numExpectedFailures += 1;
+                        } else {
+                            throw new Error(result.error);
+                        }
+                    }
+                });
+            }
+        } finally {
+            if (generateManifests) {
+                fs.mkdirSync(path.dirname(manifestFilename), {
+                    recursive: true,
+                });
+                if (Object.keys(generatedManifest).length) {
+                    fs.writeFileSync(
+                        manifestFilename,
+                        stringifyManifest(
+                            generatedManifest,
+                            expectedManifest?.comments,
+                        ),
+                    );
+                } else {
+                    // absence of the manifest file means all tests should pass
+                    fs.rmSync(manifestFilename, { force: true });
                 }
-            });
+            }
         }
     });
 }
 
-if (skipped.size !== skip.length) {
-    const extraneous = skip.filter((test) => !skipped.has(test));
-    const errorMsg = `Skipped ${skipped.size} tests, but skip.length is ${skip.length}. Missing file? Extraneous files are: ${extraneous.join(", ")}`;
-    throw new Error(errorMsg);
-}
+process.on("beforeExit", () => {
+    // log some additional diagnostics. not attempting to match `node:test`'s output since it varies by reporter
+    console.log(`Expected failures: ${numExpectedFailures}`);
+    console.log(`Unstable tests: ${numUnstableTests}`);
+});


### PR DESCRIPTION
Fixes #118. Adds some minimal `.toml` manifest files to mark which tests are expected to fail. Also adds a way to re-generate the manifest files based on the current results.

I went with `.toml` because it's simple and human-readable, and `smol-toml` is zero-dependency w/ 4M weekly downloads. I also considered just writing a basic toml parser/serializer, but it didn't seem worth it.

It's also still possible to skip tests, and unfortunately some tests still have to be skipped due to environmental issues (hangs, errors due to missing DOM globals, etc.). But I think it's nice to be explicit about which tests should pass or fail. 

We also now have a lot more passing tests, because we don't skip an entire file just because one test fails. In Node 22, we now have 1295 total passing tests (including suites) versus 1070 before. (Note this includes 78 expected failures and 6 unstable tests, so basically we have 141 new passing tests/suites.)