### PR TITLE
Mark another test as unstable

### DIFF
--- a/src/test/web-platform-tests/manifests/idbobjectstore-deleteIndex-exception-order.any.toml
+++ b/src/test/web-platform-tests/manifests/idbobjectstore-deleteIndex-exception-order.any.toml
@@ -4,3 +4,6 @@ expectation = "UNSTABLE"
 
 ["IDBObjectStore.deleteIndex exception order: InvalidStateError #1 vs. TransactionInactiveError"]
 expectation = "UNSTABLE"
+
+["IDBObjectStore.deleteIndex exception order: TransactionInactiveError vs. NotFoundError"]
+expectation = "UNSTABLE"


### PR DESCRIPTION
For me this test fails about ~1/50 times. A good way to test this is:

```sh
while [ 1==1 ]; do node src/test/web-platform-tests/converted/idbobjectstore-deleteIndex-exception-order.any.js  | grep NotFound; done
```