### PR TITLE
Optimize insertions with `multiEntry`

### DIFF
--- a/src/lib/RecordStore.ts
+++ b/src/lib/RecordStore.ts
@@ -1,9 +1,9 @@
 import FDBKeyRange from "../FDBKeyRange.js";
 import {
+    binarySearchByKeyAndValue,
     getByKey,
     getByKeyRange,
     getIndexByKey,
-    getIndexByKeyGTE,
     getIndexByKeyRange,
 } from "./binarySearch.js";
 import cmp from "./cmp.js";
@@ -26,25 +26,7 @@ class RecordStore {
         if (this.records.length === 0) {
             i = 0;
         } else {
-            i = getIndexByKeyGTE(this.records, newRecord.key);
-
-            if (i === -1) {
-                // If no matching key, add to end
-                i = this.records.length;
-            } else {
-                // If matching key, advance to appropriate position based on value (used in indexes)
-                while (
-                    i < this.records.length &&
-                    cmp(this.records[i].key, newRecord.key) === 0
-                ) {
-                    if (cmp(this.records[i].value, newRecord.value) !== -1) {
-                        // Record value >= newRecord value, so insert here
-                        break;
-                    }
-
-                    i += 1; // Look at next record
-                }
-            }
+            i = binarySearchByKeyAndValue(this.records, newRecord);
         }
 
         this.records.splice(i, 0, newRecord);

--- a/src/lib/binarySearch.ts
+++ b/src/lib/binarySearch.ts
@@ -22,6 +22,32 @@ function binarySearch(records: Record[], key: Key): number {
 }
 
 /**
+ * Same as above, but taking value into account as well, so sorting by
+ * [key, value] pairs.
+ */
+export function binarySearchByKeyAndValue(
+    records: Record[],
+    record: Record,
+): number {
+    let low = 0;
+    let high = records.length;
+    let mid;
+    while (low < high) {
+        mid = (low + high) >>> 1; // like Math.floor((low + high) / 2) but fast
+        const keyComparison = cmp(records[mid].key, record.key);
+        if (
+            keyComparison < 0 ||
+            (keyComparison === 0 && cmp(records[mid].value, record.value) < 0)
+        ) {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+    return low;
+}
+
+/**
  * Equivalent to `records.findIndex(record => cmp(record.key, key) === 0)`
  */
 export function getIndexByKey(records: Record[], key: Key): number {
@@ -75,16 +101,4 @@ export function getByKeyRange(
 ): Record | undefined {
     const idx = getIndexByKeyRange(records, keyRange);
     return records[idx];
-}
-
-/**
- * Equivalent to `records.findIndex(record => cmp(record.key, key) >= 0)`
- */
-export function getIndexByKeyGTE(records: Record[], key: Key): number {
-    const idx = binarySearch(records, key);
-    const record = records[idx];
-    if (record && cmp(record.key, key) >= 0) {
-        return idx;
-    }
-    return -1;
 }


### PR DESCRIPTION
This is a slight optimization on top of #52, to help with #44. The improvement to the original benchmark is (measuring the mean with `hyperfine`):

| Before | After | Delta |
| --- | --- | --- |
| 4.444 s ±  0.117 s | 3.985 s ±  0.098 s | **459 ms (-10%)** |

We can show the benefits more clearly by slightly tweaking ([dae0981](https://github.com/nolanlawson/fakeIndexedDB/commit/dae098173556e2a49cb02d6f5e804caaeaef8181)) the benchmark to have more duplicate `multiEntry` keys. Then the result is (`hyperfine` with 25 iterations):

| Before | After | Delta |
| --- | --- | --- |
| 419.6 ms ±  18.0 ms | 110.2 ms ±   5.5 ms | **309 ms (-74%)** |

The reason this is faster is because, instead of doing a binary search on the keys and then a linear search on the values, we are doing a binary search on both. If you have a lot of duplicate `multiEntry` keys, then you end up with a high ratio of values (i.e. record primary keys) to keys, so a linear search would be slow.

I think that if we want to get much faster than this, then we'd need to implement a BTree or similar. A lot of the remaining time is eaten up by `Array.prototype.splice()`.