### PR TITLE
Implement `"close"` event and API to simulate it

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,21 @@ import { IDBFactory } from "fake-indexeddb";
 indexedDB = new IDBFactory();
 ```
 
+### Triggering the `"close"` event
+
+An `IDBDatabase` will fire a `"close"` event when closed for [abnormal reasons](https://www.w3.org/TR/IndexedDB/#closing-connection), such as the user manually deleting databases in DevTools. If you want to simulate this event for test coverage, you can use `forceCloseDatabase()`:
+
+```js
+import { forceCloseDatabase } from "fake-indexeddb";
+
+db.addEventListener("close", () => {
+    console.log("Forcibly closed!");
+});
+forceCloseDatabase(db); // invokes the event listener
+```
+
+Note that `forceCloseDatabase()` is not a standard IndexedDB API and is unique to fake-indexeddb.
+
 ### With PhantomJS and other really old environments
 
 PhantomJS (and other really old environments) are missing tons of modern JavaScript features. In fact, that may be why you use fake-indexeddb in such an environment! Prior to v3.0.0, fake-indexeddb imported core-js and automatically applied its polyfills. However, since most fake-indexeddb users are not using really old environments, I got rid of that runtime dependency in v3.0.0. To work around that, you can import core-js yourself before you import fake-indexeddb, like:

--- a/package.json
+++ b/package.json
@@ -80,6 +80,10 @@
         "./lib/FDBVersionChangeEvent": {
             "import": "./build/esm/FDBVersionChangeEvent.js",
             "require": "./build/cjs/FDBVersionChangeEvent.js"
+        },
+        "./lib/forceCloseDatabase": {
+            "import": "./build/esm/forceCloseDatabase.js",
+            "require": "./build/cjs/forceCloseDatabase.js"
         }
     },
     "types": "./types.d.ts",

--- a/src/forceCloseDatabase.ts
+++ b/src/forceCloseDatabase.ts
@@ -1,0 +1,22 @@
+import FDBDatabase, { closeConnection } from "./FDBDatabase.js";
+
+/**
+ * Forcibly closes a database. This simulates a database being closed due to abnormal reasons, such as
+ * using DevTools to clear data while a database is open. Spec-wise, this is equivalent to
+ * [closing a database connection](https://www.w3.org/TR/IndexedDB/#closing-connection) with the `forced flag`
+ * set to true.
+ *
+ * Use this API if you want to have more test coverage for unusual IndexedDB events, such as a database firing
+ * the "close" event:
+ *
+ * ```js
+ * db.addEventListener("close", () => {
+ *   console.log("Forcibly closed!");
+ * });
+ * forceCloseDatabase(db); // invokes the event listener
+ * ```
+ * @param db
+ */
+export default function forceCloseDatabase(db: FDBDatabase) {
+    closeConnection(db, true);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,4 @@ export { default as IDBRecord } from "./FDBRecord.js";
 export { default as IDBRequest } from "./FDBRequest.js";
 export { default as IDBTransaction } from "./FDBTransaction.js";
 export { default as IDBVersionChangeEvent } from "./FDBVersionChangeEvent.js";
+export { default as forceCloseDatabase } from "./forceCloseDatabase.js";

--- a/src/lib/FakeEventTarget.ts
+++ b/src/lib/FakeEventTarget.ts
@@ -5,6 +5,7 @@ import { EventCallback, EventType } from "./types.js";
 type EventTypeProp =
     | "onabort"
     | "onblocked"
+    | "onclose"
     | "oncomplete"
     | "onerror"
     | "onsuccess"
@@ -45,6 +46,7 @@ const invokeEventListeners = (event: FakeEvent, obj: FakeEventTarget) => {
     const typeToProp: { [key in EventType]: EventTypeProp } = {
         abort: "onabort",
         blocked: "onblocked",
+        close: "onclose",
         complete: "oncomplete",
         error: "onerror",
         success: "onsuccess",
@@ -76,6 +78,7 @@ abstract class FakeEventTarget {
     // These will be overridden in individual subclasses and made not readonly
     public readonly onabort: EventCallback | null | undefined;
     public readonly onblocked: EventCallback | null | undefined;
+    public readonly onclose: EventCallback | null | undefined;
     public readonly oncomplete: EventCallback | null | undefined;
     public readonly onerror: EventCallback | null | undefined;
     public readonly onsuccess: EventCallback | null | undefined;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,7 @@ export type EventCallback = (event: EventInCallback) => void;
 export type EventType =
     | "abort"
     | "blocked"
+    | "close"
     | "complete"
     | "error"
     | "success"

--- a/src/test/fakeIndexedDB/forceCloseDatabase.ts
+++ b/src/test/fakeIndexedDB/forceCloseDatabase.ts
@@ -1,0 +1,103 @@
+import * as assert from "assert";
+import fakeIndexedDB from "../../fakeIndexedDB.js";
+import FDBDatabase from "../../FDBDatabase.js";
+import forceCloseDatabase from "../../forceCloseDatabase.js";
+
+let db: FDBDatabase;
+
+describe("forceCloseDatabase", () => {
+    beforeEach(async () => {
+        db = await new Promise<FDBDatabase>((resolve, reject) => {
+            const request = fakeIndexedDB.open("test" + Math.random());
+            request.onsuccess = (e) => resolve(e.target.result);
+            request.onerror = (e) => reject(e.target.error);
+            request.onupgradeneeded = (e) => {
+                const db = e.target.result;
+                db.createObjectStore("store", { keyPath: "key" });
+            };
+        });
+    });
+
+    it("should fire a close event when forcibly closed", async () => {
+        await new Promise<void>((resolve) => {
+            db.addEventListener("close", () => {
+                resolve();
+            });
+            forceCloseDatabase(db);
+        });
+    });
+
+    it("should not fire a close event when closed manually", async () => {
+        await new Promise<void>((resolve, reject) => {
+            db.addEventListener("close", () => {
+                reject(new Error("close event fired unexpectedly"));
+            });
+            db.close();
+            setTimeout(() => resolve());
+        });
+    });
+
+    it("should fire a close event only after transactions are complete", async () => {
+        let fired = false;
+
+        const firedPromise = new Promise<void>((resolve) => {
+            db.addEventListener("close", () => {
+                fired = true;
+                resolve();
+            });
+        });
+
+        await new Promise<void>((resolve, reject) => {
+            const txn = db.transaction("store", "readwrite");
+            forceCloseDatabase(db);
+            const store = txn.objectStore("store");
+            store.add({ key: "1" }).onsuccess = () => {
+                assert.equal(fired, false);
+                store.add({ key: "2" }).onsuccess = () => {
+                    assert.equal(fired, false);
+                    store.add({ key: "3" }).onsuccess = () => {
+                        assert.equal(fired, false);
+                    };
+                };
+            };
+            txn.oncomplete = () => resolve();
+            txn.onerror = (e) => reject(e.target.error);
+        });
+
+        await firedPromise;
+        assert.equal(fired, true);
+    });
+
+    // The spec seems to imply that the "forced" flag only applies to the connection being force closed:
+    // https://www.w3.org/TR/IndexedDB/#closing-connection
+    // In practice, all connections with the same name will be closed because it only seems to happen for cases like
+    // clearing data in DevTools, which doesn't allow you to target one IDBDatabase or another. But in our case we're
+    // just simulating the API, and the FDBDatabase object is explicitly passed in to forceCloseDatabase, so it feels
+    // more natural to just close the one database.
+    it("should not fire a close event on another database with the same name", async () => {
+        const db2 = await new Promise<FDBDatabase>((resolve, reject) => {
+            const request = fakeIndexedDB.open(db.name);
+            request.onsuccess = (e) => resolve(e.target.result);
+            request.onerror = (e) => reject(e.target.error);
+        });
+
+        assert.notEqual(db, db2);
+        assert.equal(db.name, db2.name);
+
+        const promises = [
+            new Promise<void>((resolve) => {
+                db.addEventListener("close", () => resolve());
+            }),
+            new Promise<void>((resolve, reject) => {
+                db2.addEventListener("close", () =>
+                    reject(new Error("close event fired unexpectedly")),
+                );
+                setTimeout(() => resolve());
+            }),
+        ];
+        forceCloseDatabase(db);
+        await Promise.all(promises);
+        assert.equal(db._closed, true);
+        assert.equal(db2._closed, false);
+    });
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -11,6 +11,7 @@ declare const FDBRecord: any; // should be updated once TypeScript DOM types are
 declare const FDBRequest: typeof IDBRequest;
 declare const FDBTransaction: typeof IDBTransaction;
 declare const FDBVersionChangeEvent: typeof IDBVersionChangeEvent;
+declare const forceCloseDatabase: (db: typeof FDBDatabase) => void;
 
 export default fakeIndexedDB;
 
@@ -28,4 +29,5 @@ export {
     FDBRequest as IDBRequest,
     FDBTransaction as IDBTransaction,
     FDBVersionChangeEvent as IDBVersionChangeEvent,
+    forceCloseDatabase,
 };


### PR DESCRIPTION
Closes #50. Adds a new API called `forceCloseDatabase` to [close a database with the _forced flag_](https://www.w3.org/TR/IndexedDB/#closing-connection), which triggers a `"close"` event to fire on the database.

In practice, the only way I know to repro this is by closing a database manually in DevTools. In fact I can only figure out how to do this in Chromium, because in Firefox closing a database in DevTools shows a warning ("the database will be deleted after all connections are closed"), and in WebKit the DevTools only seem to let you explore IndexedDB databases, not delete them.

There also aren't any WPT tests for this (since it is such an abnormal situation), so I wrote some Mocha tests instead.