### PR TITLE
Fix `auto` throwing an error in the browser

### DIFF
--- a/auto/index.js
+++ b/auto/index.js
@@ -22,16 +22,37 @@ var globalVar =
             ? global
             : Function("return this;")();
 
-globalVar.indexedDB = fakeIndexedDB;
-globalVar.IDBCursor = FDBCursor;
-globalVar.IDBCursorWithValue = FDBCursorWithValue;
-globalVar.IDBDatabase = FDBDatabase;
-globalVar.IDBFactory = FDBFactory;
-globalVar.IDBIndex = FDBIndex;
-globalVar.IDBKeyRange = FDBKeyRange;
-globalVar.IDBObjectStore = FDBObjectStore;
-globalVar.IDBOpenDBRequest = FDBOpenDBRequest;
-globalVar.IDBRecord = FDBRecord;
-globalVar.IDBRequest = FDBRequest;
-globalVar.IDBTransaction = FDBTransaction;
-globalVar.IDBVersionChangeEvent = FDBVersionChangeEvent;
+// Match the native behavior for `globalThis.indexedDB`, `globlThis.IDBCursor`, etc.
+// Per the IDL, `indexedDB` is readonly but the others are readwrite
+// https://w3c.github.io/IndexedDB/#idl-index
+const createPropertyDescriptor = (value, readOnly = false) => {
+    return {
+        ...(readOnly
+            ? {
+                  set: undefined,
+                  get: () => value,
+              }
+            : {
+                  value,
+                  writable: true,
+              }),
+        enumerable: true,
+        configurable: true,
+    };
+};
+
+Object.defineProperties(globalVar, {
+    indexedDB: createPropertyDescriptor(fakeIndexedDB, true),
+    IDBCursor: createPropertyDescriptor(FDBCursor),
+    IDBCursorWithValue: createPropertyDescriptor(FDBCursorWithValue),
+    IDBDatabase: createPropertyDescriptor(FDBDatabase),
+    IDBFactory: createPropertyDescriptor(FDBFactory),
+    IDBIndex: createPropertyDescriptor(FDBIndex),
+    IDBKeyRange: createPropertyDescriptor(FDBKeyRange),
+    IDBObjectStore: createPropertyDescriptor(FDBObjectStore),
+    IDBOpenDBRequest: createPropertyDescriptor(FDBOpenDBRequest),
+    IDBRecord: createPropertyDescriptor(FDBRecord),
+    IDBRequest: createPropertyDescriptor(FDBRequest),
+    IDBTransaction: createPropertyDescriptor(FDBTransaction),
+    IDBVersionChangeEvent: createPropertyDescriptor(FDBVersionChangeEvent),
+});

--- a/auto/index.mjs
+++ b/auto/index.mjs
@@ -22,16 +22,37 @@ var globalVar =
             ? global
             : Function("return this;")();
 
-globalVar.indexedDB = fakeIndexedDB;
-globalVar.IDBCursor = FDBCursor;
-globalVar.IDBCursorWithValue = FDBCursorWithValue;
-globalVar.IDBDatabase = FDBDatabase;
-globalVar.IDBFactory = FDBFactory;
-globalVar.IDBIndex = FDBIndex;
-globalVar.IDBKeyRange = FDBKeyRange;
-globalVar.IDBObjectStore = FDBObjectStore;
-globalVar.IDBOpenDBRequest = FDBOpenDBRequest;
-globalVar.IDBRecord = FDBRecord;
-globalVar.IDBRequest = FDBRequest;
-globalVar.IDBTransaction = FDBTransaction;
-globalVar.IDBVersionChangeEvent = FDBVersionChangeEvent;
+// Match the native behavior for `globalThis.indexedDB`, `globlThis.IDBCursor`, etc.
+// Per the IDL, `indexedDB` is readonly but the others are readwrite
+// https://w3c.github.io/IndexedDB/#idl-index
+const createPropertyDescriptor = (value, readOnly = false) => {
+    return {
+        ...(readOnly
+            ? {
+                  set: undefined,
+                  get: () => value,
+              }
+            : {
+                  value,
+                  writable: true,
+              }),
+        enumerable: true,
+        configurable: true,
+    };
+};
+
+Object.defineProperties(globalVar, {
+    indexedDB: createPropertyDescriptor(fakeIndexedDB, true),
+    IDBCursor: createPropertyDescriptor(FDBCursor),
+    IDBCursorWithValue: createPropertyDescriptor(FDBCursorWithValue),
+    IDBDatabase: createPropertyDescriptor(FDBDatabase),
+    IDBFactory: createPropertyDescriptor(FDBFactory),
+    IDBIndex: createPropertyDescriptor(FDBIndex),
+    IDBKeyRange: createPropertyDescriptor(FDBKeyRange),
+    IDBObjectStore: createPropertyDescriptor(FDBObjectStore),
+    IDBOpenDBRequest: createPropertyDescriptor(FDBOpenDBRequest),
+    IDBRecord: createPropertyDescriptor(FDBRecord),
+    IDBRequest: createPropertyDescriptor(FDBRequest),
+    IDBTransaction: createPropertyDescriptor(FDBTransaction),
+    IDBVersionChangeEvent: createPropertyDescriptor(FDBVersionChangeEvent),
+});

--- a/src/test/fakeIndexedDB/auto.ts
+++ b/src/test/fakeIndexedDB/auto.ts
@@ -1,0 +1,52 @@
+import * as assert from "assert";
+import * as fakeIndexedDB from "../../index.js";
+
+// `indexedDB` is read-only, all others are read-write
+const readWriteProps = Object.keys(fakeIndexedDB).filter((prop) =>
+    prop.startsWith("IDB"),
+) as Array<keyof typeof fakeIndexedDB>;
+
+describe("auto", () => {
+    it("correctly overrides globals in fake-indexeddb/auto", async () => {
+        // simulate what the native property descriptors do
+        Object.defineProperty(globalThis, "indexedDB", {
+            set: undefined,
+            get: () => undefined,
+            enumerable: true,
+            configurable: true,
+        });
+        for (const prop of readWriteProps) {
+            Object.defineProperty(globalThis, prop, {
+                value: undefined,
+                enumerable: true,
+                configurable: true,
+                writable: true,
+            });
+        }
+
+        // @ts-expect-error relative to the build/ directory
+        await import("../../../../auto/index.mjs");
+
+        // check read-only indexedDB global
+        const descriptor = Object.getOwnPropertyDescriptor(
+            globalThis,
+            "indexedDB",
+        );
+        assert.equal(descriptor!.set, undefined);
+        assert.equal(descriptor!.get!(), fakeIndexedDB.indexedDB);
+        assert.equal(descriptor!.enumerable, true);
+        assert.equal(descriptor!.configurable, true);
+
+        // check read-write globals
+        for (const prop of readWriteProps) {
+            const descriptor = Object.getOwnPropertyDescriptor(
+                globalThis,
+                prop,
+            );
+            assert.equal(descriptor!.value, fakeIndexedDB[prop]);
+            assert.equal(descriptor!.enumerable, true);
+            assert.equal(descriptor!.configurable, true);
+            assert.equal(descriptor!.writable, true);
+        }
+    });
+});


### PR DESCRIPTION
Fixes #83

The problem with doing a basic `globalThis.indexedDB = fakeIndexedDB` is that the native descriptor has a `get` but an undefined `set`, so it throws with the basic assignment. This doesn't occur in Node because none of these globals are set before `auto` runs.

The fix is pretty straightforward: we have to follow the [IDL spec](https://w3c.github.io/IndexedDB/#idl-index) for globals like `indexedDB` and do an `Object/defineProperty`/`Object.defineProperties`, being careful to set it with the proper configuration (e.g. configurable=true, enumerable=true). This configuration depends on the global: `indexedDB` is read-only whereas the others are read-write.