### PR TITLE
Fix CommonJS `default` export

### DIFF
--- a/src/forceCloseDatabase.ts
+++ b/src/forceCloseDatabase.ts
@@ -1,4 +1,5 @@
-import FDBDatabase, { closeConnection } from "./FDBDatabase.js";
+import FDBDatabase from "./FDBDatabase.js";
+import closeConnection from "./lib/closeConnection.js";
 
 /**
  * Forcibly closes a database. This simulates a database being closed due to abnormal reasons, such as

--- a/src/lib/closeConnection.ts
+++ b/src/lib/closeConnection.ts
@@ -1,0 +1,36 @@
+import FakeEvent from "./FakeEvent.js";
+import { queueTask } from "./scheduling.js";
+import FDBDatabase from "../FDBDatabase";
+
+// http://www.w3.org/TR/2015/REC-IndexedDB-20150108/#database-closing-steps
+const closeConnection = (connection: FDBDatabase, forced: boolean = false) => {
+    connection._closePending = true;
+
+    const transactionsComplete = connection._rawDatabase.transactions.every(
+        (transaction) => {
+            return transaction._state === "finished";
+        },
+    );
+
+    if (transactionsComplete) {
+        connection._closed = true;
+        connection._rawDatabase.connections =
+            connection._rawDatabase.connections.filter((otherConnection) => {
+                return connection !== otherConnection;
+            });
+        if (forced) {
+            const event = new FakeEvent("close", {
+                bubbles: false,
+                cancelable: false,
+            });
+            event.eventPath = [];
+            connection.dispatchEvent(event);
+        }
+    } else {
+        queueTask(() => {
+            closeConnection(connection, forced);
+        });
+    }
+};
+
+export default closeConnection;

--- a/src/test/fakeIndexedDB/auto.ts
+++ b/src/test/fakeIndexedDB/auto.ts
@@ -49,4 +49,15 @@ describe("auto", () => {
             assert.equal(descriptor!.writable, true);
         }
     });
+
+    it("exports as cjs directly, without `default` member - issue #130", async () => {
+        // @ts-expect-error relative to the build/ directory
+        await import("../../../../auto/index.js");
+
+        // ensure we directly set the export as `module.exports` rather than `module.exports.default`
+        assert.ok(!(globalThis as any).indexedDB.default);
+        for (const prop of readWriteProps) {
+            assert.ok(!(globalThis as any)[prop].default);
+        }
+    });
 });


### PR DESCRIPTION
Fixes #130 

This was caused by #126 and is due to the extra `export` in `FDBDatabase.ts`. To fix it, we can simply move `closeConnection` to its own file.