### PR TITLE
Update indexedDB initialization after #127

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ import "fake-indexeddb/auto";
 import { IDBFactory } from "fake-indexeddb";
 
 // Whenever you want a fresh indexedDB
-indexedDB = new IDBFactory();
+Object.defineProperty(globalThis, 'indexedDB', { value: new IDBFactory() });
 ```
 
 ### Triggering the `"close"` event


### PR DESCRIPTION
As a result of #127, reassigning the `indexedDB` global, as instructed in the README, no longer works. These updated instructions work in my test suite.