### PR TITLE
Fix `globalThis.indexedDB = ...`

### DIFF
--- a/auto/index.js
+++ b/auto/index.js
@@ -22,27 +22,21 @@ var globalVar =
             ? global
             : Function("return this;")();
 
-// Match the native behavior for `globalThis.indexedDB`, `globlThis.IDBCursor`, etc.
-// Per the IDL, `indexedDB` is readonly but the others are readwrite
+// Partly match the native behavior for `globalThis.indexedDB`, `globalThis.IDBCursor`, etc.
+// Per the IDL, `indexedDB` is readonly but the others are readwrite. For us, though, we want it to still
+// be overwritable with `globalThis.<global> = ...`, so we make them all readwrite.
 // https://w3c.github.io/IndexedDB/#idl-index
-const createPropertyDescriptor = (value, readOnly = false) => {
+const createPropertyDescriptor = (value) => {
     return {
-        ...(readOnly
-            ? {
-                  set: undefined,
-                  get: () => value,
-              }
-            : {
-                  value,
-                  writable: true,
-              }),
+        value,
         enumerable: true,
         configurable: true,
+        writable: true,
     };
 };
 
 Object.defineProperties(globalVar, {
-    indexedDB: createPropertyDescriptor(fakeIndexedDB, true),
+    indexedDB: createPropertyDescriptor(fakeIndexedDB),
     IDBCursor: createPropertyDescriptor(FDBCursor),
     IDBCursorWithValue: createPropertyDescriptor(FDBCursorWithValue),
     IDBDatabase: createPropertyDescriptor(FDBDatabase),

--- a/auto/index.mjs
+++ b/auto/index.mjs
@@ -22,27 +22,21 @@ var globalVar =
             ? global
             : Function("return this;")();
 
-// Match the native behavior for `globalThis.indexedDB`, `globlThis.IDBCursor`, etc.
-// Per the IDL, `indexedDB` is readonly but the others are readwrite
+// Partly match the native behavior for `globalThis.indexedDB`, `globalThis.IDBCursor`, etc.
+// Per the IDL, `indexedDB` is readonly but the others are readwrite. For us, though, we want it to still
+// be overwritable with `globalThis.<global> = ...`, so we make them all readwrite.
 // https://w3c.github.io/IndexedDB/#idl-index
-const createPropertyDescriptor = (value, readOnly = false) => {
+const createPropertyDescriptor = (value) => {
     return {
-        ...(readOnly
-            ? {
-                  set: undefined,
-                  get: () => value,
-              }
-            : {
-                  value,
-                  writable: true,
-              }),
+        value,
         enumerable: true,
         configurable: true,
+        writable: true,
     };
 };
 
 Object.defineProperties(globalVar, {
-    indexedDB: createPropertyDescriptor(fakeIndexedDB, true),
+    indexedDB: createPropertyDescriptor(fakeIndexedDB),
     IDBCursor: createPropertyDescriptor(FDBCursor),
     IDBCursorWithValue: createPropertyDescriptor(FDBCursorWithValue),
     IDBDatabase: createPropertyDescriptor(FDBDatabase),


### PR DESCRIPTION
Proposed fix for `globalThis.indexedDB = ...` ala https://github.com/dumbmatter/fakeIndexedDB/issues/134#issuecomment-3238780720. Basically we can just make every global readwrite instead of perfectly matching the spec.

Fixes #134 if this seems reasonable.