### PR TITLE
Use default priority for `scheduler.postTask`

### DIFF
--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -26,10 +26,12 @@ interface Scheduler {
 }
 declare const scheduler: Scheduler;
 
-// 'user-blocking' runs right after microtasks, so equivalent to setTimeout but without the 4ms clamping
+// 'postTask' runs right after microtasks, so equivalent to setTimeout but without the 4ms clamping.
+// Using the default priority of 'user-visible' to avoid blocking input while still running fairly quickly.
+// See: https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities
 const schedulerPostTask =
     typeof scheduler !== "undefined" &&
-    ((fn: () => void) => scheduler.postTask(fn, { priority: "user-blocking" }));
+    ((fn: () => void) => scheduler.postTask(fn));
 
 // fallback for environments that don't support any of the above
 const doSetTimeout = (fn: () => void) => setTimeout(fn, 0);


### PR DESCRIPTION
After more testing and research, I don't think it's appropriate to use `scheduler.postTask()` with `priority: 'user-blocking'` as I did in https://github.com/dumbmatter/fakeIndexedDB/pull/129. According to [my benchmarks](https://nolanlawson.github.io/fake-indexeddb-timer-benchmark/), all [three priorities](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities) run almost identically for fakeIndexedDB's use case (in both Chrome and Firefox), but the issue with `user-blocking` is that it could be a footgun if fakeIndexedDB were actually used in production on a real website. The default `user-visible` priority seems to match our use case better:

> [user-blocking](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#user-blocking)
> Tasks that stop users from interacting with the page. This includes rendering the page to the point where it can be used, or responding to user input.
>
> [user-visible](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#user-visible) 
> Tasks that are visible to the user but not necessarily blocking user actions. This might include rendering non-essential parts of the page, such as non-essential images or animations.
> This is the default priority for scheduler.postTask() and scheduler.yield().
>
> [background](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#background)
> Tasks that are not time-critical. This might include log processing or initializing third party libraries that aren't required for rendering.

