### PR TITLE
Refactor "is a potentially valid key range"

### DIFF
--- a/src/lib/extractGetAllOptions.ts
+++ b/src/lib/extractGetAllOptions.ts
@@ -12,8 +12,12 @@ const extractGetAllOptions = (
     let query: FDBKeyRange | Key;
     let direction: FDBCursorDirection | undefined;
 
-    if (isPotentiallyValidKeyRange(queryOrOptions)) {
-        // queryOrOptions is FDBKeyRange | Key
+    if (
+        queryOrOptions === undefined ||
+        queryOrOptions === null ||
+        isPotentiallyValidKeyRange(queryOrOptions)
+    ) {
+        // queryOrOptions is FDBKeyRange | Key | null | undefined
         query = queryOrOptions;
         if (numArguments > 1 && count !== undefined) {
             count = enforceRange(count, "unsigned long");

--- a/src/lib/isPotentiallyValidKeyRange.ts
+++ b/src/lib/isPotentiallyValidKeyRange.ts
@@ -1,32 +1,21 @@
 import FDBKeyRange from "../FDBKeyRange.js";
-import isSharedArrayBuffer from "./isSharedArrayBuffer.js";
+import valueToKeyWithoutThrowing, {
+    INVALID_TYPE,
+} from "./valueToKeyWithoutThrowing.js";
 
 // https://www.w3.org/TR/IndexedDB/#is-a-potentially-valid-key-range
 const isPotentiallyValidKeyRange = (value: any): boolean => {
-    // Many of these conditions recapitulate the same conditions in `valueToKeyRange.ts`
-    return (
-        // FDBKeyRange
-        value instanceof FDBKeyRange ||
-        // null/undefined - nullDisallowedFlag=false is assumed here
-        value === null ||
-        value === undefined ||
-        // Number
-        typeof value === "number" ||
-        // Date
-        Object.prototype.toString.call(value) === "[object Date]" ||
-        // string
-        typeof value === "string" ||
-        // buffer source type
-        // note: we are explicitly _not_ checking for detachedness here, to match Chromium's behavior
-        // see: https://github.com/w3c/IndexedDB/issues/465
-        value instanceof ArrayBuffer ||
-        isSharedArrayBuffer(value) ||
-        (typeof ArrayBuffer !== "undefined" &&
-            ArrayBuffer.isView &&
-            ArrayBuffer.isView(value)) ||
-        // array exotic type
-        Array.isArray(value)
-    );
+    // If value is a key range, return true.
+    if (value instanceof FDBKeyRange) {
+        return true;
+    }
+
+    // Let key be the result of converting a value to a key with value.
+    const key = valueToKeyWithoutThrowing(value);
+
+    // If key is "invalid type" return false.
+    // Else return true.
+    return key !== INVALID_TYPE;
 };
 
 export default isPotentiallyValidKeyRange;

--- a/src/lib/valueToKeyWithoutThrowing.ts
+++ b/src/lib/valueToKeyWithoutThrowing.ts
@@ -1,0 +1,88 @@
+import isSharedArrayBuffer from "./isSharedArrayBuffer.js";
+import type { Key } from "./types.js";
+
+export const INVALID_TYPE = Symbol("INVALID_TYPE");
+export const INVALID_VALUE = Symbol("INVALID_VALUE");
+
+// https://w3c.github.io/IndexedDB/#convert-value-to-key
+// The "without exceptions" version is because we typically want to throw exceptions (DataError) but not for
+// the "is potentially valid key range" routine.
+const valueToKeyWithoutThrowing = (
+    input: any,
+    seen?: Set<object>,
+): Key | Key[] | typeof INVALID_TYPE | typeof INVALID_VALUE => {
+    if (typeof input === "number") {
+        if (isNaN(input)) {
+            // If input is NaN then return "invalid value".
+            return INVALID_VALUE;
+        }
+        return input;
+    } else if (Object.prototype.toString.call(input) === "[object Date]") {
+        const ms = input.valueOf();
+        if (isNaN(ms)) {
+            // If ms is NaN then return "invalid value".
+            return INVALID_VALUE;
+        }
+        return new Date(ms);
+    } else if (typeof input === "string") {
+        return input;
+    } else if (
+        // https://w3c.github.io/IndexedDB/#ref-for-dfn-buffer-source-type
+        input instanceof ArrayBuffer ||
+        isSharedArrayBuffer(input) ||
+        (typeof ArrayBuffer !== "undefined" &&
+            ArrayBuffer.isView &&
+            ArrayBuffer.isView(input))
+    ) {
+        // We can't consistently test detachedness, so instead we check if byteLength === 0
+        // This isn't foolproof, but there's no perfect way to detect if Uint8Arrays or
+        // SharedArrayBuffers are detached
+        if ("detached" in input ? input.detached : input.byteLength === 0) {
+            // If input is detached then return "invalid value".
+            return INVALID_VALUE;
+        }
+        let arrayBuffer;
+        let offset = 0;
+        let length = 0;
+        if (input instanceof ArrayBuffer || isSharedArrayBuffer(input)) {
+            arrayBuffer = input;
+            length = input.byteLength;
+        } else {
+            arrayBuffer = input.buffer;
+            offset = input.byteOffset;
+            length = input.byteLength;
+        }
+
+        return arrayBuffer.slice(offset, offset + length);
+    } else if (Array.isArray(input)) {
+        if (seen === undefined) {
+            seen = new Set();
+        } else if (seen.has(input)) {
+            // If seen contains input, then return "invalid value".
+            return INVALID_VALUE;
+        }
+        seen.add(input);
+
+        const keys = [];
+        for (let i = 0; i < input.length; i++) {
+            const hop = Object.hasOwn(input, i);
+            if (!hop) {
+                // If hop is false, return "invalid value".
+                return INVALID_VALUE;
+            }
+            const entry = input[i];
+            const key = valueToKeyWithoutThrowing(entry, seen);
+            // If key is "invalid value" or "invalid type" abort these steps and return "invalid value".
+            if (key === INVALID_VALUE || key === INVALID_TYPE) {
+                return INVALID_VALUE;
+            }
+            keys.push(key);
+        }
+        return keys;
+    } else {
+        // Otherwise: Return "invalid type".
+        return INVALID_TYPE;
+    }
+};
+
+export default valueToKeyWithoutThrowing;


### PR DESCRIPTION
This is a minor refactor of the ["is a potentially valid key range"](https://w3c.github.io/IndexedDB/#potentially-valid-key-range) steps to better match the spec. Originally I had misunderstood the changes to the spec to accommodate `GetAllOptions`, which were explained to me here: https://github.com/w3c/IndexedDB/issues/465#issuecomment-3169028742

Now that I understand the spec better, we can deduplicate some of the logic in `isPotentiallyValidKeyRange` and `valueToKey`.