### PR TITLE
Correctly handle `onupgradeneeded` listener errors

### DIFF
--- a/src/test/web-platform-tests/manifests/fire-upgradeneeded-event-exception.any.toml
+++ b/src/test/web-platform-tests/manifests/fire-upgradeneeded-event-exception.any.toml
@@ -1,2 +1,0 @@
-# These are pretty tricky. Would be nice to have them working.
-skip = true


### PR DESCRIPTION
Fixes #138 

This fixes the `fire-upgradeneeded-event-exception.any` test by 1) wrapping `onupgradeneeded` listener calls in `try`/`catch` and aborting the transaction in case of an error, and 2) aggregating errors from multiple listeners for the odd case where there are multiple `onupgradeneeded` listeners and only one throws an error.

I also added some more comments to clarify which steps correspond to the spec language, which is here: https://w3c.github.io/IndexedDB/#upgrade-a-database