### PR TITLE
Handle errors in `success`/`error` listeners

### DIFF
--- a/src/test/web-platform-tests/manifests/fire-error-event-exception.any.toml
+++ b/src/test/web-platform-tests/manifests/fire-error-event-exception.any.toml
@@ -1,2 +1,0 @@
-# These are pretty tricky. Would be nice to have them working.
-skip = true

--- a/src/test/web-platform-tests/manifests/fire-success-event-exception.any.toml
+++ b/src/test/web-platform-tests/manifests/fire-success-event-exception.any.toml
@@ -1,2 +1,0 @@
-# These are pretty tricky. Would be nice to have them working.
-skip = true


### PR DESCRIPTION
Follow-up to #139 

This does the minimum changes to fix the remaining `fire-*-event-exception.any` tests. This is mostly just a matter of putting the `try`/`catch`es around the `dispatchEvent` calls.

I didn't try to make the code perfectly match the spec in this case, but the previously-failing tests are indeed passing now.