### PR TITLE
Fix `get-databases.any.toml` test

### DIFF
--- a/src/FDBDatabase.ts
+++ b/src/FDBDatabase.ts
@@ -45,6 +45,7 @@ class FDBDatabase extends FakeEventTarget {
     public _closePending = false;
     public _closed = false;
     public _runningVersionchangeTransaction = false;
+    public _oldVersion: number | undefined;
     public _rawDatabase: Database;
 
     public name: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -60,3 +60,9 @@ export type FDBTransactionDurability = "default" | "strict" | "relaxed";
 export type FDBTransactionOptions = {
     durability: FDBTransactionDurability;
 };
+
+// https://w3c.github.io/IndexedDB/#dictdef-idbdatabaseinfo
+export type FDBDatabaseInfo = {
+    name: string;
+    version: number;
+};

--- a/src/test/web-platform-tests/convert.js
+++ b/src/test/web-platform-tests/convert.js
@@ -1,12 +1,12 @@
 /* global console */
 import fs from "node:fs";
-import { glob } from "glob";
 import path from "node:path";
+import { glob } from "glob";
 
 // HACK: some of the tests use sloppy mode, probably due to author error
 // This causes problems for us because we convert to ESM (strict) mode
 // So manually fix some of the sloppy global assignments in tests
-const globalVars = ["cursor", "db", "store", "value"];
+const globalVars = ["cursor", "db", "result", "store", "value"];
 const declareGlobalVars = `let ${globalVars.join(",")};\n`;
 
 const skip = [

--- a/src/test/web-platform-tests/converted/abort-in-initial-upgradeneeded.any.js
+++ b/src/test/web-platform-tests/converted/abort-in-initial-upgradeneeded.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB";
 

--- a/src/test/web-platform-tests/converted/bindings-inject-keys-bypass.any.js
+++ b/src/test/web-platform-tests/converted/bindings-inject-keys-bypass.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: ES bindings - Inject a key into a value - Keys bypass setters";
 

--- a/src/test/web-platform-tests/converted/bindings-inject-values-bypass.any.js
+++ b/src/test/web-platform-tests/converted/bindings-inject-values-bypass.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: ES bindings - Inject a key into a value - Values bypass chain and setters";
 

--- a/src/test/web-platform-tests/converted/blob-composite-blob-reads.any.js
+++ b/src/test/web-platform-tests/converted/blob-composite-blob-reads.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDB-backed composite blobs maintain coherency";
 

--- a/src/test/web-platform-tests/converted/blob-contenttype.any.js
+++ b/src/test/web-platform-tests/converted/blob-contenttype.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Blob Content Type";
 

--- a/src/test/web-platform-tests/converted/blob-delete-objectstore-db.any.js
+++ b/src/test/web-platform-tests/converted/blob-delete-objectstore-db.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Blob Delete Object Store";
 

--- a/src/test/web-platform-tests/converted/blob-valid-after-abort.any.js
+++ b/src/test/web-platform-tests/converted/blob-valid-after-abort.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Blob Valid After Abort";
 

--- a/src/test/web-platform-tests/converted/blob-valid-after-deletion.any.js
+++ b/src/test/web-platform-tests/converted/blob-valid-after-deletion.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Blob Valid After Deletion";
 

--- a/src/test/web-platform-tests/converted/blob-valid-before-commit.any.js
+++ b/src/test/web-platform-tests/converted/blob-valid-before-commit.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Blob Valid Before Commit";
 

--- a/src/test/web-platform-tests/converted/clone-before-keypath-eval.any.js
+++ b/src/test/web-platform-tests/converted/clone-before-keypath-eval.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: clone before key path evaluation";
 

--- a/src/test/web-platform-tests/converted/close-in-upgradeneeded.any.js
+++ b/src/test/web-platform-tests/converted/close-in-upgradeneeded.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB";
 

--- a/src/test/web-platform-tests/converted/cursor-overloads.any.js
+++ b/src/test/web-platform-tests/converted/cursor-overloads.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB";
 

--- a/src/test/web-platform-tests/converted/database-names-by-origin.js
+++ b/src/test/web-platform-tests/converted/database-names-by-origin.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 'use strict';
 

--- a/src/test/web-platform-tests/converted/delete-range.any.js
+++ b/src/test/web-platform-tests/converted/delete-range.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Delete range";
 

--- a/src/test/web-platform-tests/converted/delete-request-queue.any.js
+++ b/src/test/web-platform-tests/converted/delete-request-queue.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB";
 

--- a/src/test/web-platform-tests/converted/error-attributes.any.js
+++ b/src/test/web-platform-tests/converted/error-attributes.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB";
 

--- a/src/test/web-platform-tests/converted/event-dispatch-active-flag.any.js
+++ b/src/test/web-platform-tests/converted/event-dispatch-active-flag.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB Transaction - active flag is set during event dispatch";
 

--- a/src/test/web-platform-tests/converted/file_support.sub.js
+++ b/src/test/web-platform-tests/converted/file_support.sub.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 'use strict';
 

--- a/src/test/web-platform-tests/converted/fire-error-event-exception.any.js
+++ b/src/test/web-platform-tests/converted/fire-error-event-exception.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Fire error event - Exception thrown";
 

--- a/src/test/web-platform-tests/converted/fire-success-event-exception.any.js
+++ b/src/test/web-platform-tests/converted/fire-success-event-exception.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Fire success event - Exception thrown";
 

--- a/src/test/web-platform-tests/converted/fire-upgradeneeded-event-exception.any.js
+++ b/src/test/web-platform-tests/converted/fire-upgradeneeded-event-exception.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Fire upgradeneeded event - Exception thrown";
 

--- a/src/test/web-platform-tests/converted/get-databases.any.js
+++ b/src/test/web-platform-tests/converted/get-databases.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 'use strict';
 

--- a/src/test/web-platform-tests/converted/globalscope-indexedDB-SameObject.any.js
+++ b/src/test/web-platform-tests/converted/globalscope-indexedDB-SameObject.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Verify [SameObject] behavior of the global scope's indexedDB attribute";
 

--- a/src/test/web-platform-tests/converted/historical.any.js
+++ b/src/test/web-platform-tests/converted/historical.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Historical features";
 

--- a/src/test/web-platform-tests/converted/idb-binary-key-detached.any.js
+++ b/src/test/web-platform-tests/converted/idb-binary-key-detached.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = " IndexedDB: Detached buffers supplied as binary keys";
 

--- a/src/test/web-platform-tests/converted/idb-binary-key-roundtrip.any.js
+++ b/src/test/web-platform-tests/converted/idb-binary-key-roundtrip.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Binary keys written to a database and read back";
 

--- a/src/test/web-platform-tests/converted/idb-explicit-commit-throw.any.js
+++ b/src/test/web-platform-tests/converted/idb-explicit-commit-throw.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 'use strict';
 

--- a/src/test/web-platform-tests/converted/idb-explicit-commit.any.js
+++ b/src/test/web-platform-tests/converted/idb-explicit-commit.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 'use strict';
 

--- a/src/test/web-platform-tests/converted/idb-partitioned-basic.sub.js
+++ b/src/test/web-platform-tests/converted/idb-partitioned-basic.sub.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 
 // Here's the set-up for this test:

--- a/src/test/web-platform-tests/converted/idb-partitioned-coverage.sub.js
+++ b/src/test/web-platform-tests/converted/idb-partitioned-coverage.sub.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 
 fetch_tests_from_window(document.getElementById("iframe").contentWindow);

--- a/src/test/web-platform-tests/converted/idb-partitioned-persistence.sub.js
+++ b/src/test/web-platform-tests/converted/idb-partitioned-persistence.sub.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 
 // Here's the set-up for this test:

--- a/src/test/web-platform-tests/converted/idb_binary_key_conversion.any.js
+++ b/src/test/web-platform-tests/converted/idb_binary_key_conversion.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Verify the conversion of various types of BufferSource";
 

--- a/src/test/web-platform-tests/converted/idb_webworkers.js
+++ b/src/test/web-platform-tests/converted/idb_webworkers.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/idbcursor-advance-continue-async.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-advance-continue-async.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor asyncness";
 

--- a/src/test/web-platform-tests/converted/idbcursor-advance-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-advance-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBCursor advance() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbcursor-advance-invalid.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-advance-invalid.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.advance() - invalid";
 

--- a/src/test/web-platform-tests/converted/idbcursor-advance.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-advance.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.advance()";
 

--- a/src/test/web-platform-tests/converted/idbcursor-continue-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-continue-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBCursor continue() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.continuePrimaryKey() - Exception Orders";
 

--- a/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey-exceptions.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey-exceptions.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBCursor continuePrimaryKey() exception throwing";
 

--- a/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-continuePrimaryKey.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBCursor method continuePrimaryKey()";
 

--- a/src/test/web-platform-tests/converted/idbcursor-delete-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-delete-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBCursor delete() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbcursor-direction-index-keyrange.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-direction-index-keyrange.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor direction - index with keyrange";
 

--- a/src/test/web-platform-tests/converted/idbcursor-direction-index.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-direction-index.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor direction - index";
 

--- a/src/test/web-platform-tests/converted/idbcursor-direction-objectstore-keyrange.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-direction-objectstore-keyrange.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor direction - object store with keyrange";
 

--- a/src/test/web-platform-tests/converted/idbcursor-direction-objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-direction-objectstore.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor direction - object store";
 

--- a/src/test/web-platform-tests/converted/idbcursor-direction.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-direction.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.direction";
 

--- a/src/test/web-platform-tests/converted/idbcursor-iterating-update.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-iterating-update.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Index iteration with cursor updates/deletes";
 

--- a/src/test/web-platform-tests/converted/idbcursor-key.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-key.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.key";
 

--- a/src/test/web-platform-tests/converted/idbcursor-primarykey.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-primarykey.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.primaryKey";
 

--- a/src/test/web-platform-tests/converted/idbcursor-request-source.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-request-source.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: The source of requests made against cursors";
 

--- a/src/test/web-platform-tests/converted/idbcursor-request.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-request.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/idbcursor-reused.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-reused.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor is reused";
 

--- a/src/test/web-platform-tests/converted/idbcursor-source.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-source.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.source";
 

--- a/src/test/web-platform-tests/converted/idbcursor-update-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor-update-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBCursor update() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbcursor_advance_index.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_advance_index.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.advance()";
 

--- a/src/test/web-platform-tests/converted/idbcursor_advance_objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_advance_objectstore.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.advance()";
 

--- a/src/test/web-platform-tests/converted/idbcursor_continue_delete_objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_continue_delete_objectstore.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.delete() and IDBCursor.continue()";
 

--- a/src/test/web-platform-tests/converted/idbcursor_continue_index.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_continue_index.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.continue() - index";
 

--- a/src/test/web-platform-tests/converted/idbcursor_continue_invalid.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_continue_invalid.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.continue()";
 

--- a/src/test/web-platform-tests/converted/idbcursor_continue_objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_continue_objectstore.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.continue() - object store";
 

--- a/src/test/web-platform-tests/converted/idbcursor_delete_index.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_delete_index.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.delete() - index";
 

--- a/src/test/web-platform-tests/converted/idbcursor_delete_objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_delete_objectstore.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.delete() - object store";
 

--- a/src/test/web-platform-tests/converted/idbcursor_iterating.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_iterating.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.continue() - object store";
 

--- a/src/test/web-platform-tests/converted/idbcursor_update_index.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_update_index.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.update() - index";
 

--- a/src/test/web-platform-tests/converted/idbcursor_update_objectstore.any.js
+++ b/src/test/web-platform-tests/converted/idbcursor_update_objectstore.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBCursor.update() - object store";
 

--- a/src/test/web-platform-tests/converted/idbdatabase-createObjectStore-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase-createObjectStore-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBDatabase createObjectStore() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbdatabase-deleteObjectStore-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase-deleteObjectStore-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBDatabase deleteObjectStore() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbdatabase-transaction-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase-transaction-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBDatabase transaction() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbdatabase_close.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase_close.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBDatabase.close()";
 

--- a/src/test/web-platform-tests/converted/idbdatabase_createObjectStore.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase_createObjectStore.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBDatabase.createObjectStore()";
 

--- a/src/test/web-platform-tests/converted/idbdatabase_deleteObjectStore.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase_deleteObjectStore.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBDatabase.deleteObjectStore()";
 

--- a/src/test/web-platform-tests/converted/idbdatabase_transaction.any.js
+++ b/src/test/web-platform-tests/converted/idbdatabase_transaction.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBDatabase.transaction()";
 

--- a/src/test/web-platform-tests/converted/idbfactory-databases-opaque-origin.js
+++ b/src/test/web-platform-tests/converted/idbfactory-databases-opaque-origin.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 
 

--- a/src/test/web-platform-tests/converted/idbfactory-deleteDatabase-opaque-origin.js
+++ b/src/test/web-platform-tests/converted/idbfactory-deleteDatabase-opaque-origin.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 
 

--- a/src/test/web-platform-tests/converted/idbfactory-deleteDatabase-request-success.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory-deleteDatabase-request-success.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBFactory deleteDatabase()";
 

--- a/src/test/web-platform-tests/converted/idbfactory-open-error-properties.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory-open-error-properties.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBFactory open() error event properties";
 

--- a/src/test/web-platform-tests/converted/idbfactory-open-opaque-origin.js
+++ b/src/test/web-platform-tests/converted/idbfactory-open-opaque-origin.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 
 

--- a/src/test/web-platform-tests/converted/idbfactory-open-request-error.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory-open-request-error.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBFactory open(): request properties on error";
 

--- a/src/test/web-platform-tests/converted/idbfactory-open-request-success.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory-open-request-success.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBFactory open(): request properties on success";
 

--- a/src/test/web-platform-tests/converted/idbfactory-origin-isolation.js
+++ b/src/test/web-platform-tests/converted/idbfactory-origin-isolation.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/idbfactory_cmp.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory_cmp.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBFactory.cmp()";
 

--- a/src/test/web-platform-tests/converted/idbfactory_deleteDatabase.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory_deleteDatabase.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBFactory.deleteDatabase()";
 

--- a/src/test/web-platform-tests/converted/idbfactory_open.any.js
+++ b/src/test/web-platform-tests/converted/idbfactory_open.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBFactory.open()";
 

--- a/src/test/web-platform-tests/converted/idbindex-cross-realm-methods.js
+++ b/src/test/web-platform-tests/converted/idbindex-cross-realm-methods.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/idbindex-getAll-enforcerange.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-getAll-enforcerange.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBIndex getAll() uses [EnforceRange]";
 

--- a/src/test/web-platform-tests/converted/idbindex-getAllKeys-enforcerange.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-getAllKeys-enforcerange.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBIndex getAllKeys() uses [EnforceRange]";
 

--- a/src/test/web-platform-tests/converted/idbindex-multientry.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-multientry.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBIndex.multiEntry";
 

--- a/src/test/web-platform-tests/converted/idbindex-objectStore-SameObject.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-objectStore-SameObject.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: objectStore SameObject";
 

--- a/src/test/web-platform-tests/converted/idbindex-query-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-query-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBIndex query method Ordering";
 

--- a/src/test/web-platform-tests/converted/idbindex-rename-abort.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-rename-abort.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: index renaming support in aborted transactions";
 

--- a/src/test/web-platform-tests/converted/idbindex-rename-errors.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-rename-errors.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: index renaming error handling";
 

--- a/src/test/web-platform-tests/converted/idbindex-rename.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-rename.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: index renaming support";
 

--- a/src/test/web-platform-tests/converted/idbindex-request-source.any.js
+++ b/src/test/web-platform-tests/converted/idbindex-request-source.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: The source of requests made against indexes";
 

--- a/src/test/web-platform-tests/converted/idbindex_count.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_count.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBIndex.count()";
 

--- a/src/test/web-platform-tests/converted/idbindex_get.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_get.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBIndex.get()";
 

--- a/src/test/web-platform-tests/converted/idbindex_getAll-options.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getAll-options.tentative.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBIndex.getAll with options dictionary.";
 

--- a/src/test/web-platform-tests/converted/idbindex_getAll.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getAll.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBIndex.getAll";
 

--- a/src/test/web-platform-tests/converted/idbindex_getAllKeys-options.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getAllKeys-options.tentative.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBIndex.getAllKeys with options dictionary.";
 

--- a/src/test/web-platform-tests/converted/idbindex_getAllKeys.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getAllKeys.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBIndex.getAllKeys.";
 

--- a/src/test/web-platform-tests/converted/idbindex_getAllRecords.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getAllRecords.tentative.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBIndex.getAllRecords";
 

--- a/src/test/web-platform-tests/converted/idbindex_getKey.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_getKey.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBIndex.getKey()";
 

--- a/src/test/web-platform-tests/converted/idbindex_indexNames.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_indexNames.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.indexNames";
 

--- a/src/test/web-platform-tests/converted/idbindex_keyPath.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_keyPath.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBIndex keyPath attribute";
 

--- a/src/test/web-platform-tests/converted/idbindex_openCursor.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_openCursor.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBIndex.openCursor()";
 

--- a/src/test/web-platform-tests/converted/idbindex_openKeyCursor.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_openKeyCursor.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBIndex.openKeyCursor()";
 

--- a/src/test/web-platform-tests/converted/idbindex_reverse_cursor.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_reverse_cursor.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Reverse Cursor Validity";
 

--- a/src/test/web-platform-tests/converted/idbindex_tombstones.any.js
+++ b/src/test/web-platform-tests/converted/idbindex_tombstones.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Index Tombstones";
 

--- a/src/test/web-platform-tests/converted/idbkeyrange-includes.any.js
+++ b/src/test/web-platform-tests/converted/idbkeyrange-includes.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBKeyRange.includes()";
 

--- a/src/test/web-platform-tests/converted/idbkeyrange.any.js
+++ b/src/test/web-platform-tests/converted/idbkeyrange.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBKeyRange Tests";
 

--- a/src/test/web-platform-tests/converted/idbkeyrange_incorrect.any.js
+++ b/src/test/web-platform-tests/converted/idbkeyrange_incorrect.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBKeyRange Tests - Incorrect";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-add-put-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-add-put-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBObjectStore add()/put() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-clear-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-clear-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBObjectStore clear() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-cross-realm-methods.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-cross-realm-methods.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/idbobjectstore-delete-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-delete-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBObjectStore delete() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-deleteIndex-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-deleteIndex-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBObjectStore deleteIndex() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-getAll-enforcerange.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-getAll-enforcerange.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBObjectStore getAll() uses [EnforceRange]";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-getAllKeys-enforcerange.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-getAllKeys-enforcerange.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBIObjectStore getAllKeys() uses [EnforceRange]";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-index-finished.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-index-finished.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBObjectStore index() when transaction is finished";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-query-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-query-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBObjectStore query method Ordering";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-rename-abort.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-rename-abort.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: object store renaming support in aborted transactions";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-rename-errors.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-rename-errors.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: object store renaming error handling";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-rename-store.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-rename-store.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: object store renaming support";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-request-source.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-request-source.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: The source of requests made against object stores";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore-transaction-SameObject.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore-transaction-SameObject.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Verify [SameObject] behavior of IDBObjectStore's transaction attribute";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_add.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_add.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.add()";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_clear.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_clear.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.clear()";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_count.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_count.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.count()";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_createIndex.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_createIndex.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.createIndex()";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_delete.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_delete.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.delete()";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_deleteIndex.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_deleteIndex.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.deleteIndex()";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_get.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_get.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.get()";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_getAll-options.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getAll-options.tentative.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBObjectStore.getAll with options dictionary.";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_getAll.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getAll.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBObjectStore.getAll";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_getAllKeys-options.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getAllKeys-options.tentative.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBObjectStore.getAllKeys with options dictionary.";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_getAllKeys.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getAllKeys.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBObjectStore.getAllKeys";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_getAllRecords.tentative.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getAllRecords.tentative.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBObjectStore.getAllRecords";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_getKey.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_getKey.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test IDBObjectStore.getKey()";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_index.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_index.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.index() - returns an index";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_keyPath.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_keyPath.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBObjectStore keyPath attribute - same object";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_openCursor.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_openCursor.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.openCursor() - iterate through 100 objects";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_openCursor_invalid.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_openCursor_invalid.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.openCursor() - invalid";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_openKeyCursor.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_openKeyCursor.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.openKeyCursor()";
 

--- a/src/test/web-platform-tests/converted/idbobjectstore_put.any.js
+++ b/src/test/web-platform-tests/converted/idbobjectstore_put.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore.put()";
 

--- a/src/test/web-platform-tests/converted/idbrequest-onupgradeneeded.any.js
+++ b/src/test/web-platform-tests/converted/idbrequest-onupgradeneeded.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBRequest onupgradeneeded tests";
 

--- a/src/test/web-platform-tests/converted/idbrequest_error.any.js
+++ b/src/test/web-platform-tests/converted/idbrequest_error.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBRequest.error";
 

--- a/src/test/web-platform-tests/converted/idbrequest_result.any.js
+++ b/src/test/web-platform-tests/converted/idbrequest_result.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBRequest.result";
 

--- a/src/test/web-platform-tests/converted/idbtransaction-db-SameObject.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction-db-SameObject.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Verify [SameObject] behavior of IDBTransaction's db attribute";
 

--- a/src/test/web-platform-tests/converted/idbtransaction-objectStore-exception-order.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction-objectStore-exception-order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBTransaction objectStore() Exception Ordering";
 

--- a/src/test/web-platform-tests/converted/idbtransaction-objectStore-finished.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction-objectStore-finished.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBTransaction objectStore() when transaction is finished";
 

--- a/src/test/web-platform-tests/converted/idbtransaction-oncomplete.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction-oncomplete.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBTransaction - complete event";
 

--- a/src/test/web-platform-tests/converted/idbtransaction.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBTransaction";
 

--- a/src/test/web-platform-tests/converted/idbtransaction_abort.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction_abort.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBTransaction - abort";
 

--- a/src/test/web-platform-tests/converted/idbtransaction_objectStoreNames.any.js
+++ b/src/test/web-platform-tests/converted/idbtransaction_objectStoreNames.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: IDBTransaction.objectStoreNames attribute";
 

--- a/src/test/web-platform-tests/converted/idbversionchangeevent.any.js
+++ b/src/test/web-platform-tests/converted/idbversionchangeevent.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBVersionChangeEvent";
 

--- a/src/test/web-platform-tests/converted/index_sort_order.any.js
+++ b/src/test/web-platform-tests/converted/index_sort_order.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = " IDBIndex Key sort order";
 

--- a/src/test/web-platform-tests/converted/interleaved-cursors-large.any.js
+++ b/src/test/web-platform-tests/converted/interleaved-cursors-large.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Interleaved iteration of multiple cursors";
 

--- a/src/test/web-platform-tests/converted/interleaved-cursors-small.any.js
+++ b/src/test/web-platform-tests/converted/interleaved-cursors-small.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Interleaved iteration of multiple cursors";
 

--- a/src/test/web-platform-tests/converted/key-conversion-exceptions.any.js
+++ b/src/test/web-platform-tests/converted/key-conversion-exceptions.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Exceptions thrown during key conversion";
 

--- a/src/test/web-platform-tests/converted/key_invalid.any.js
+++ b/src/test/web-platform-tests/converted/key_invalid.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Invalid key";
 

--- a/src/test/web-platform-tests/converted/key_valid.any.js
+++ b/src/test/web-platform-tests/converted/key_valid.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Valid key";
 

--- a/src/test/web-platform-tests/converted/keygenerator.any.js
+++ b/src/test/web-platform-tests/converted/keygenerator.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/keyorder.any.js
+++ b/src/test/web-platform-tests/converted/keyorder.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Key sort order";
 

--- a/src/test/web-platform-tests/converted/keypath-exceptions.any.js
+++ b/src/test/web-platform-tests/converted/keypath-exceptions.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Exceptions in extracting keys from values (ES bindings)";
 

--- a/src/test/web-platform-tests/converted/keypath-special-identifiers.any.js
+++ b/src/test/web-platform-tests/converted/keypath-special-identifiers.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Special-cased identifiers in extracting keys from values (ES bindings)";
 

--- a/src/test/web-platform-tests/converted/keypath.any.js
+++ b/src/test/web-platform-tests/converted/keypath.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Keypath";
 

--- a/src/test/web-platform-tests/converted/keypath_invalid.any.js
+++ b/src/test/web-platform-tests/converted/keypath_invalid.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Invalid keypath";
 

--- a/src/test/web-platform-tests/converted/keypath_maxsize.any.js
+++ b/src/test/web-platform-tests/converted/keypath_maxsize.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Keypath";
 

--- a/src/test/web-platform-tests/converted/large-requests-abort.any.js
+++ b/src/test/web-platform-tests/converted/large-requests-abort.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: transactions with large request results are aborted correctly";
 

--- a/src/test/web-platform-tests/converted/list_ordering.any.js
+++ b/src/test/web-platform-tests/converted/list_ordering.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "ObjectStoreNames and indexNames ordering";
 

--- a/src/test/web-platform-tests/converted/name-scopes.any.js
+++ b/src/test/web-platform-tests/converted/name-scopes.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: scoping for database / object store / index names, and index keys";
 

--- a/src/test/web-platform-tests/converted/nested-cloning-basic.any.js
+++ b/src/test/web-platform-tests/converted/nested-cloning-basic.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: basic objects are cloned correctly";
 

--- a/src/test/web-platform-tests/converted/nested-cloning-large-multiple.any.js
+++ b/src/test/web-platform-tests/converted/nested-cloning-large-multiple.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: large nested objects are cloned correctly";
 

--- a/src/test/web-platform-tests/converted/nested-cloning-large.any.js
+++ b/src/test/web-platform-tests/converted/nested-cloning-large.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: large nested objects are cloned correctly";
 

--- a/src/test/web-platform-tests/converted/nested-cloning-small.any.js
+++ b/src/test/web-platform-tests/converted/nested-cloning-small.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: small nested objects are cloned correctly";
 

--- a/src/test/web-platform-tests/converted/objectstore_keyorder.any.js
+++ b/src/test/web-platform-tests/converted/objectstore_keyorder.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IDBObjectStore key sort order";
 

--- a/src/test/web-platform-tests/converted/open-request-queue.any.js
+++ b/src/test/web-platform-tests/converted/open-request-queue.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: open and delete request queues";
 

--- a/src/test/web-platform-tests/converted/parallel-cursors-upgrade.any.js
+++ b/src/test/web-platform-tests/converted/parallel-cursors-upgrade.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Parallel iteration of cursors in upgradeneeded";
 

--- a/src/test/web-platform-tests/converted/reading-autoincrement-indexes-cursors.any.js
+++ b/src/test/web-platform-tests/converted/reading-autoincrement-indexes-cursors.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 'use strict';
 

--- a/src/test/web-platform-tests/converted/reading-autoincrement-indexes.any.js
+++ b/src/test/web-platform-tests/converted/reading-autoincrement-indexes.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 'use strict';
 

--- a/src/test/web-platform-tests/converted/reading-autoincrement-store-cursors.any.js
+++ b/src/test/web-platform-tests/converted/reading-autoincrement-store-cursors.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 'use strict';
 

--- a/src/test/web-platform-tests/converted/reading-autoincrement-store.any.js
+++ b/src/test/web-platform-tests/converted/reading-autoincrement-store.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 'use strict';
 

--- a/src/test/web-platform-tests/converted/ready-state-destroyed-execution-context.js
+++ b/src/test/web-platform-tests/converted/ready-state-destroyed-execution-context.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/request-abort-ordering.any.js
+++ b/src/test/web-platform-tests/converted/request-abort-ordering.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: request abort events are delivered in order";
 

--- a/src/test/web-platform-tests/converted/request-event-ordering-large-mixed-with-small-values.any.js
+++ b/src/test/web-platform-tests/converted/request-event-ordering-large-mixed-with-small-values.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: request result events are delivered in order";
 

--- a/src/test/web-platform-tests/converted/request-event-ordering-large-then-small-values.any.js
+++ b/src/test/web-platform-tests/converted/request-event-ordering-large-then-small-values.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: request result events are delivered in order";
 

--- a/src/test/web-platform-tests/converted/request-event-ordering-large-values.any.js
+++ b/src/test/web-platform-tests/converted/request-event-ordering-large-values.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: request result events are delivered in order";
 

--- a/src/test/web-platform-tests/converted/request-event-ordering-small-values.any.js
+++ b/src/test/web-platform-tests/converted/request-event-ordering-small-values.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: request result events are delivered in order";
 

--- a/src/test/web-platform-tests/converted/request_bubble-and-capture.any.js
+++ b/src/test/web-platform-tests/converted/request_bubble-and-capture.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Bubbling and capturing of request events";
 

--- a/src/test/web-platform-tests/converted/resources/cross-origin-helper-frame.js
+++ b/src/test/web-platform-tests/converted/resources/cross-origin-helper-frame.js
@@ -1,6 +1,6 @@
 import "../../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 
 'use strict';

--- a/src/test/web-platform-tests/converted/resources/idb-partitioned-basic-iframe.js
+++ b/src/test/web-platform-tests/converted/resources/idb-partitioned-basic-iframe.js
@@ -1,6 +1,6 @@
 import "../../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 
 const dbName = "users";

--- a/src/test/web-platform-tests/converted/resources/idb-partitioned-coverage-iframe.js
+++ b/src/test/web-platform-tests/converted/resources/idb-partitioned-coverage-iframe.js
@@ -1,6 +1,6 @@
 import "../../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/resources/idb-partitioned-persistence-iframe.js
+++ b/src/test/web-platform-tests/converted/resources/idb-partitioned-persistence-iframe.js
@@ -1,6 +1,6 @@
 import "../../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 
 const dbName = "users";

--- a/src/test/web-platform-tests/converted/resources/idbfactory-origin-isolation-iframe.js
+++ b/src/test/web-platform-tests/converted/resources/idbfactory-origin-isolation-iframe.js
@@ -1,6 +1,6 @@
 import "../../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 
 

--- a/src/test/web-platform-tests/converted/serialize-sharedarraybuffer-throws.https.js
+++ b/src/test/web-platform-tests/converted/serialize-sharedarraybuffer-throws.https.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/storage-buckets.https.any.js
+++ b/src/test/web-platform-tests/converted/storage-buckets.https.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Buckets API: Tests for indexedDB API.";
 

--- a/src/test/web-platform-tests/converted/string-list-ordering.any.js
+++ b/src/test/web-platform-tests/converted/string-list-ordering.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB string list ordering";
 

--- a/src/test/web-platform-tests/converted/structured-clone-transaction-state.any.js
+++ b/src/test/web-platform-tests/converted/structured-clone-transaction-state.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Indexed DB transaction state during Structured Serializing";
 

--- a/src/test/web-platform-tests/converted/structured-clone.any.js
+++ b/src/test/web-platform-tests/converted/structured-clone.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Indexed DB and Structured Serializing/Deserializing";
 

--- a/src/test/web-platform-tests/converted/transaction-abort-generator-revert.any.js
+++ b/src/test/web-platform-tests/converted/transaction-abort-generator-revert.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: aborting transactions reverts an object store's key generator state";
 

--- a/src/test/web-platform-tests/converted/transaction-abort-index-metadata-revert.any.js
+++ b/src/test/web-platform-tests/converted/transaction-abort-index-metadata-revert.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: aborting transactions reverts index metadata";
 

--- a/src/test/web-platform-tests/converted/transaction-abort-multiple-metadata-revert.any.js
+++ b/src/test/web-platform-tests/converted/transaction-abort-multiple-metadata-revert.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: aborting transactions reverts multiple operations on the same metadata";
 

--- a/src/test/web-platform-tests/converted/transaction-abort-object-store-metadata-revert.any.js
+++ b/src/test/web-platform-tests/converted/transaction-abort-object-store-metadata-revert.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: aborting transactions reverts object store metadata";
 

--- a/src/test/web-platform-tests/converted/transaction-abort-request-error.any.js
+++ b/src/test/web-platform-tests/converted/transaction-abort-request-error.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Test error events fired at requests from aborted transaction";
 

--- a/src/test/web-platform-tests/converted/transaction-create_in_versionchange.any.js
+++ b/src/test/web-platform-tests/converted/transaction-create_in_versionchange.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB Transaction Creation During Version Change";
 

--- a/src/test/web-platform-tests/converted/transaction-deactivation-timing.any.js
+++ b/src/test/web-platform-tests/converted/transaction-deactivation-timing.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB Transaction Deactivation Timing";
 

--- a/src/test/web-platform-tests/converted/transaction-lifetime-empty.any.js
+++ b/src/test/web-platform-tests/converted/transaction-lifetime-empty.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: Commit ordering of empty transactions";
 

--- a/src/test/web-platform-tests/converted/transaction-lifetime.any.js
+++ b/src/test/web-platform-tests/converted/transaction-lifetime.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Event order when opening a second database when one connection is open already";
 

--- a/src/test/web-platform-tests/converted/transaction-relaxed-durability.any.js
+++ b/src/test/web-platform-tests/converted/transaction-relaxed-durability.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 'use strict';
 

--- a/src/test/web-platform-tests/converted/transaction-requestqueue.any.js
+++ b/src/test/web-platform-tests/converted/transaction-requestqueue.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB Transaction Request Queue Handling";
 

--- a/src/test/web-platform-tests/converted/transaction-scheduling-across-connections.any.js
+++ b/src/test/web-platform-tests/converted/transaction-scheduling-across-connections.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/transaction-scheduling-across-databases.any.js
+++ b/src/test/web-platform-tests/converted/transaction-scheduling-across-databases.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/transaction-scheduling-mixed-scopes.any.js
+++ b/src/test/web-platform-tests/converted/transaction-scheduling-mixed-scopes.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/transaction-scheduling-ordering.any.js
+++ b/src/test/web-platform-tests/converted/transaction-scheduling-ordering.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/transaction-scheduling-ro-waits-for-rw.any.js
+++ b/src/test/web-platform-tests/converted/transaction-scheduling-ro-waits-for-rw.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/transaction-scheduling-rw-scopes.any.js
+++ b/src/test/web-platform-tests/converted/transaction-scheduling-rw-scopes.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/transaction-scheduling-within-database.any.js
+++ b/src/test/web-platform-tests/converted/transaction-scheduling-within-database.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 /* Delete created databases
  *

--- a/src/test/web-platform-tests/converted/transaction_bubble-and-capture.any.js
+++ b/src/test/web-platform-tests/converted/transaction_bubble-and-capture.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB Transaction Event Bubbling and Capturing";
 

--- a/src/test/web-platform-tests/converted/upgrade-transaction-deactivation-timing.any.js
+++ b/src/test/web-platform-tests/converted/upgrade-transaction-deactivation-timing.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "Upgrade transaction deactivation timing";
 

--- a/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-backend-aborted.any.js
+++ b/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-backend-aborted.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: backend-aborted versionchange transaction lifecycle";
 

--- a/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-committed.any.js
+++ b/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-committed.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: committed versionchange transaction lifecycle";
 

--- a/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-user-aborted.any.js
+++ b/src/test/web-platform-tests/converted/upgrade-transaction-lifecycle-user-aborted.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: user-abort()ed versionchange transaction lifecycle";
 

--- a/src/test/web-platform-tests/converted/value_recursive.any.js
+++ b/src/test/web-platform-tests/converted/value_recursive.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB: recursive value";
 

--- a/src/test/web-platform-tests/converted/writer-starvation.any.js
+++ b/src/test/web-platform-tests/converted/writer-starvation.any.js
@@ -1,6 +1,6 @@
 import "../wpt-env.js";
 
-let cursor,db,store,value;
+let cursor,db,result,store,value;
 
 globalThis.title = "IndexedDB writer starvation test";
 

--- a/src/test/web-platform-tests/manifests/get-databases.any.toml
+++ b/src/test/web-platform-tests/manifests/get-databases.any.toml
@@ -1,6 +1,0 @@
-# Mostly works, except the last test which is edge cases
-["Enumerate multiple databases."]
-expectation = "FAIL"
-
-["Ensure that databases() doesn't pick up changes that haven't commited."]
-expectation = "FAIL"


### PR DESCRIPTION
This test was a pretty simple fix: the `FDBFactory.databases()` function just needs to report the _old_ versions of any databases that have in-flight `versionchange` transactions, and to filter any newly-created databases (i.e. version is 0).