### PR TITLE
Fix transaction ordering by scope

### DIFF
--- a/src/lib/Database.ts
+++ b/src/lib/Database.ts
@@ -1,4 +1,5 @@
 import { queueTask } from "./scheduling.js";
+import { intersection } from "./intersection.js";
 import type FDBDatabase from "../FDBDatabase.js";
 import type FDBTransaction from "../FDBTransaction.js";
 import type ObjectStore from "./ObjectStore.js";
@@ -21,25 +22,44 @@ class Database {
 
     public processTransactions() {
         queueTask(() => {
-            const anyRunning = this.transactions.some((transaction) => {
-                return (
-                    transaction._started && transaction._state !== "finished"
+            const running = this.transactions.filter(
+                (transaction) =>
+                    transaction._started && transaction._state !== "finished",
+            );
+
+            const waiting = this.transactions.filter(
+                (transaction) =>
+                    !transaction._started && transaction._state !== "finished",
+            );
+
+            // The next transaction to run is the first waiting one that doesn't overlap with either a running one or a
+            // preceding waiting one. This allows non-overlapping transactions to run in parallel.
+            const next = waiting.find((transaction, i) => {
+                const anyRunning = running.some(
+                    (other) =>
+                        intersection(other._scope, transaction._scope).size > 0,
                 );
+                if (anyRunning) {
+                    return false;
+                }
+
+                // If any _preceding_ waiting transactions are blocked, then that's also blocking.
+                // E.g. if you have 3 transactions: [a], [a,b], and [b,c], then [a] blocks [a,b] which blocks [b,c]
+                // until [a] is complete, even though [a] and [b,c] share no overlap.
+                const anyWaiting = waiting
+                    .slice(0, i)
+                    .some(
+                        (other) =>
+                            intersection(other._scope, transaction._scope)
+                                .size > 0,
+                    );
+                return !anyWaiting;
             });
 
-            if (!anyRunning) {
-                const next = this.transactions.find((transaction) => {
-                    return (
-                        !transaction._started &&
-                        transaction._state !== "finished"
-                    );
-                });
-
-                if (next) {
-                    next.addEventListener("complete", this.processTransactions);
-                    next.addEventListener("abort", this.processTransactions);
-                    next._start();
-                }
+            if (next) {
+                next.addEventListener("complete", this.processTransactions);
+                next.addEventListener("abort", this.processTransactions);
+                next._start();
             }
         });
     }

--- a/src/lib/intersection.ts
+++ b/src/lib/intersection.ts
@@ -1,0 +1,12 @@
+/**
+ * Minimal polyfill of `Set.prototype.intersection`, available in Node 22+.
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/intersection
+ * @param set1
+ * @param set2
+ */
+export function intersection<T>(set1: Set<T>, set2: Set<T>): Set<T> {
+    if ("intersection" in set1) {
+        return set1.intersection(set2);
+    }
+    return new Set([...set1].filter((item) => set2.has(item)));
+}

--- a/src/test/web-platform-tests/manifests/idb-explicit-commit-throw.any.toml
+++ b/src/test/web-platform-tests/manifests/idb-explicit-commit-throw.any.toml
@@ -1,3 +1,0 @@
-# Not sure how to do this weird error silencing in Node.js.
-["Any errors in callbacks that run after an explicit commit will not stop the commit from being processed."]
-expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idb-explicit-commit.any.toml
+++ b/src/test/web-platform-tests/manifests/idb-explicit-commit.any.toml
@@ -1,2 +1,4 @@
-# Mostly works, but keepAlive results in an infinite loop
-skip = true
+# Timing issue: `keepAlive` keeps the transaction alive indefinitely whereas `timeoutPromise` assumes it will make the
+# transaction inactive, causing `commit()` to throw
+["Calling txn.commit() when txn is inactive should throw."]
+expectation = "FAIL"

--- a/src/test/web-platform-tests/wpt-env.js
+++ b/src/test/web-platform-tests/wpt-env.js
@@ -72,6 +72,11 @@ global.postMessage = (obj) => {
     structuredClone(obj);
 };
 
+global.addEventListener = () => {
+    // no-op, the `idb-explicit-commit-throw.any.js` test currently
+    // tries to `addEventListener('error')` and `preventDefault` on it
+};
+
 const generatedTestNames = new Map();
 let generatedTestNameCounter = 0;
 function generateTestName(func) {


### PR DESCRIPTION
This fixes most of the `idb-explicit-commit` tests by changing how we do transaction ordering.

Instead of running all transactions in serial, we can run some in parallel based on their object store scope. For example, a transaction with scope of `[a]` would block a transaction with scope `[a,b]`. (We could also get fancy with the `readwrite`/`readonly` distinction, but this didn't seem to affect the tests so I didn't bother for now.)

Implementing this logic fixes _most_ of the tests, except for a small timing issue which I added a comment about.