### PR TITLE
Fire `error` async, fix  `idbindex` tests

### DIFF
--- a/src/test/web-platform-tests/manifests/idbindex_get.any.toml
+++ b/src/test/web-platform-tests/manifests/idbindex_get.any.toml
@@ -1,7 +1,0 @@
-# Fails because FDBTransaction._abort synchronously sends out error events to open requests, when it should be
-# asynchronous according to the spec. Making it asynchronous causes other tests to fail though. Need to be more
-# careful about making sure other asynchronous things are actually asynchronous, and also "asynchronous" doesn't
-# just mean "wrap in setImmediate", in this context it means to wait until prior requests are complete and then
-# execute.
-["get() throws InvalidStateError on index deleted by aborted upgrade"]
-expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbindex_getKey.any.toml
+++ b/src/test/web-platform-tests/manifests/idbindex_getKey.any.toml
@@ -1,7 +1,0 @@
-# Fails because FDBTransaction._abort synchronously sends out error events to open requests, when it should be
-# asynchronous according to the spec. Making it asynchronous causes other tests to fail though. Need to be more
-# careful about making sure other asynchronous things are actually asynchronous, and also "asynchronous" doesn't
-# just mean "wrap in setImmediate", in this context it means to wait until prior requests are complete and then
-# execute.
-["getKey() throws InvalidStateError on index deleted by aborted upgrade"]
-expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbindex_openCursor.any.toml
+++ b/src/test/web-platform-tests/manifests/idbindex_openCursor.any.toml
@@ -1,7 +1,0 @@
-# Fails because FDBTransaction._abort synchronously sends out error events to open requests, when it should be
-# asynchronous according to the spec. Making it asynchronous causes other tests to fail though. Need to be more
-# careful about making sure other asynchronous things are actually asynchronous, and also "asynchronous" doesn't
-# just mean "wrap in setImmediate", in this context it means to wait until prior requests are complete and then
-# execute.
-["If the index is deleted by an aborted upgrade, throw InvalidStateError"]
-expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbindex_openKeyCursor.any.toml
+++ b/src/test/web-platform-tests/manifests/idbindex_openKeyCursor.any.toml
@@ -1,7 +1,0 @@
-# Fails because FDBTransaction._abort synchronously sends out error events to open requests, when it should be
-# asynchronous according to the spec. Making it asynchronous causes other tests to fail though. Need to be more
-# careful about making sure other asynchronous things are actually asynchronous, and also "asynchronous" doesn't
-# just mean "wrap in setImmediate", in this context it means to wait until prior requests are complete and then
-# execute.
-["Throw InvalidStateError on index deleted by aborted upgrade"]
-expectation = "FAIL"


### PR DESCRIPTION
Fixes 4 tests by firing the `error` event asynchronously, as described by the spec.

The comment:

https://github.com/dumbmatter/fakeIndexedDB/blob/6acd53ae705470fdf385269257f40f70218e024b/src/test/web-platform-tests/manifests/idbindex_get.any.toml#L1-L5

... implies that making this async should break other tests. But it doesn't, so maybe something changed in the interim?