### PR TITLE
Sort manifest during generation

### DIFF
--- a/src/test/web-platform-tests/manifests/idbfactory-databases-opaque-origin.toml
+++ b/src/test/web-platform-tests/manifests/idbfactory-databases-opaque-origin.toml
@@ -1,12 +1,12 @@
 # Did not investigate in great detail.
-["IDBFactory.databases() in non-sandboxed iframe should not reject"]
-expectation = "FAIL"
-
-["IDBFactory.databases() in sandboxed iframe should reject"]
-expectation = "FAIL"
-
 ["IDBFactory.databases() in data URL dedicated worker should throw SecurityError"]
 expectation = "FAIL"
 
 ["IDBFactory.databases() in data URL shared worker should throw SecurityError"]
+expectation = "FAIL"
+
+["IDBFactory.databases() in non-sandboxed iframe should not reject"]
+expectation = "FAIL"
+
+["IDBFactory.databases() in sandboxed iframe should reject"]
 expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbfactory-deleteDatabase-opaque-origin.toml
+++ b/src/test/web-platform-tests/manifests/idbfactory-deleteDatabase-opaque-origin.toml
@@ -1,12 +1,12 @@
 # No iframe in Node.js.
-["IDBFactory.deleteDatabase() in non-sandboxed iframe should not throw"]
-expectation = "FAIL"
-
-["IDBFactory.deleteDatabase() in sandboxed iframe should throw SecurityError"]
-expectation = "FAIL"
-
 ["IDBFactory.deleteDatabase() in data URL dedicated worker should throw SecurityError"]
 expectation = "FAIL"
 
 ["IDBFactory.deleteDatabase() in data URL shared worker should throw SecurityError"]
+expectation = "FAIL"
+
+["IDBFactory.deleteDatabase() in non-sandboxed iframe should not throw"]
+expectation = "FAIL"
+
+["IDBFactory.deleteDatabase() in sandboxed iframe should throw SecurityError"]
 expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbfactory-open-opaque-origin.toml
+++ b/src/test/web-platform-tests/manifests/idbfactory-open-opaque-origin.toml
@@ -1,12 +1,12 @@
 # No iframe in Node.js.
-["IDBFactory.open() in non-sandboxed iframe should not throw"]
-expectation = "FAIL"
-
-["IDBFactory.open() in sandboxed iframe should throw SecurityError"]
-expectation = "FAIL"
-
 ["IDBFactory.open() in data URL dedicated workers should throw SecurityError"]
 expectation = "FAIL"
 
 ["IDBFactory.open() in data URL shared workers should throw SecurityError"]
+expectation = "FAIL"
+
+["IDBFactory.open() in non-sandboxed iframe should not throw"]
+expectation = "FAIL"
+
+["IDBFactory.open() in sandboxed iframe should throw SecurityError"]
 expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbobjectstore-cross-realm-methods.toml
+++ b/src/test/web-platform-tests/manifests/idbobjectstore-cross-realm-methods.toml
@@ -1,20 +1,17 @@
 # relies on cross-iframe/cross-window communication which isn't relevant to us
-["Cross-realm IDBObjectStore::put() method from detached <iframe> works as expected"]
-expectation = "FAIL"
-
 ["Cross-realm IDBObjectStore::add() method from detached <iframe> works as expected"]
-expectation = "FAIL"
-
-["Cross-realm IDBObjectStore::delete() method from detached <iframe> works as expected"]
 expectation = "FAIL"
 
 ["Cross-realm IDBObjectStore::clear() method from detached <iframe> works as expected"]
 expectation = "FAIL"
 
-["Cross-realm IDBObjectStore::get() method from detached <iframe> works as expected"]
+["Cross-realm IDBObjectStore::count() method from detached <iframe> works as expected"]
 expectation = "FAIL"
 
-["Cross-realm IDBObjectStore::getKey() method from detached <iframe> works as expected"]
+["Cross-realm IDBObjectStore::delete() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::get() method from detached <iframe> works as expected"]
 expectation = "FAIL"
 
 ["Cross-realm IDBObjectStore::getAll() method from detached <iframe> works as expected"]
@@ -23,11 +20,14 @@ expectation = "FAIL"
 ["Cross-realm IDBObjectStore::getAllKeys() method from detached <iframe> works as expected"]
 expectation = "FAIL"
 
-["Cross-realm IDBObjectStore::count() method from detached <iframe> works as expected"]
+["Cross-realm IDBObjectStore::getKey() method from detached <iframe> works as expected"]
 expectation = "FAIL"
 
 ["Cross-realm IDBObjectStore::openCursor() method from detached <iframe> works as expected"]
 expectation = "FAIL"
 
 ["Cross-realm IDBObjectStore::openKeyCursor() method from detached <iframe> works as expected"]
+expectation = "FAIL"
+
+["Cross-realm IDBObjectStore::put() method from detached <iframe> works as expected"]
 expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/idbobjectstore-deleteIndex-exception-order.any.toml
+++ b/src/test/web-platform-tests/manifests/idbobjectstore-deleteIndex-exception-order.any.toml
@@ -1,9 +1,9 @@
 # these tests rely on the precise ordering of exceptions, which we currently fail sometimes
+["IDBObjectStore.deleteIndex exception order: InvalidStateError #1 vs. TransactionInactiveError"]
+expectation = "UNSTABLE"
+
 ["IDBObjectStore.deleteIndex exception order: InvalidStateError #2 vs. TransactionInactiveError"]
 expectation = "UNSTABLE"
 
 ["IDBObjectStore.deleteIndex exception order: TransactionInactiveError vs. NotFoundError"]
-expectation = "UNSTABLE"
-
-["IDBObjectStore.deleteIndex exception order: InvalidStateError #1 vs. TransactionInactiveError"]
 expectation = "UNSTABLE"

--- a/src/test/web-platform-tests/manifests/structured-clone-transaction-state.any.toml
+++ b/src/test/web-platform-tests/manifests/structured-clone-transaction-state.any.toml
@@ -1,9 +1,9 @@
 # these test our ability to do a structured clone on various DOM types like DOMRect which we don't support
+["Transaction inactive during structured clone in IDBCursor.update()"]
+expectation = "FAIL"
+
 ["Transaction inactive during structured clone in IDBObjectStore.add()"]
 expectation = "FAIL"
 
 ["Transaction inactive during structured clone in IDBObjectStore.put()"]
-expectation = "FAIL"
-
-["Transaction inactive during structured clone in IDBCursor.update()"]
 expectation = "FAIL"

--- a/src/test/web-platform-tests/run-all.js
+++ b/src/test/web-platform-tests/run-all.js
@@ -134,10 +134,17 @@ for (const absFilename of filenames) {
                     recursive: true,
                 });
                 if (Object.keys(generatedManifest).length) {
+                    // Sort to avoid issues where some tests complete before
+                    // others in non-deterministic order
+                    const sortedGeneratedManifest = Object.fromEntries(
+                        Object.keys(generatedManifest)
+                            .sort()
+                            .map((key) => [key, generatedManifest[key]]),
+                    );
                     fs.writeFileSync(
                         manifestFilename,
                         stringifyManifest(
-                            generatedManifest,
+                            sortedGeneratedManifest,
                             expectedManifest?.comments,
                         ),
                     );


### PR DESCRIPTION
Fixes #149. I think we can just sort the keys before writing the manifest file – this should fix the non-determinism.