### PR TITLE
Fix `Duplicate test results` error

### DIFF
--- a/src/test/web-platform-tests/wpt-env.js
+++ b/src/test/web-platform-tests/wpt-env.js
@@ -68,6 +68,7 @@ class GenericCloneable {
     "DOMRectReadOnly",
 ].forEach((Clazz) => {
     global[Clazz] = class extends GenericCloneable {};
+    Object.defineProperty(global[Clazz], "name", { value: Clazz });
 });
 global.ImageData = class extends GenericCloneable {
     constructor() {
@@ -101,8 +102,8 @@ global.document = {
     // Kind of cheating for key_invalid.js: It wants to test using a DOM node as a key, but that can't work in Node, so
     // this will instead use another object that also can't be used as a key.
     getElementsByTagName: () => Math,
-    // structured-clone.any.js created an `<input type=file multiple>`
-    createElement: () => ({ files: [] }),
+    // structured-clone.any.js creates an `<input type=file multiple>`
+    createElement: () => ({ files: [{ name: "foo.txt" }] }),
 };
 global.location = {
     location: {},


### PR DESCRIPTION
[This error](https://github.com/dumbmatter/fakeIndexedDB/actions/runs/18436878753/job/52531561759) was caused by #151 due to me not ensuring that tests have unique names. Sorry about that! This fixes it.