### PR TITLE
Fix `MessageChannel` clone error in Node 18/20

### DIFF
--- a/src/test/web-platform-tests/wpt-env.js
+++ b/src/test/web-platform-tests/wpt-env.js
@@ -90,9 +90,11 @@ global.structuredClone = function customStructuredClone(obj) {
         });
     } else if (obj instanceof GenericCloneable) {
         return obj.__clone();
-    } else if (obj instanceof Event) {
+    } else if (obj instanceof Event || obj instanceof MessageChannel) {
         // FakeEvent should be non-serializable, same as native Event
         // TODO [#140]: use native Event/EventTarget
+        // As for MessageChannel, in Node 22+ the error is a proper DataCloneError
+        // but currently we need this for Node 18/20 support
         throw new DataCloneError("not serializable");
     }
     return originalStructuredClone(obj);


### PR DESCRIPTION
In Node 18/20 calling `structuredClone` on a `MessageChannel` does not produce the expected `DataCloneError`. We can patch this temporarily in `wpt-env.js` until we drop support for Node <=20 (Node 20 is [EOL in April 2026](https://endoflife.date/nodejs)).