### PR TITLE
Fix `bindings-inject-*` tests

### DIFF
--- a/src/lib/ObjectStore.ts
+++ b/src/lib/ObjectStore.ts
@@ -166,7 +166,14 @@ class ObjectStore {
                         remainingKeyPath = remainingKeyPath.slice(i + 1);
 
                         if (!Object.hasOwn(object, identifier)) {
-                            object[identifier] = {};
+                            // Bypass prototype when setting (See `bindings-inject-values-bypass.any.js`)
+                            // Equivalent to `object[identifier] = ...` without using `Object.prototype`
+                            Object.defineProperty(object, identifier, {
+                                configurable: true,
+                                enumerable: true,
+                                writable: true,
+                                value: {},
+                            });
                         }
 
                         object = object[identifier];
@@ -175,7 +182,14 @@ class ObjectStore {
 
                 identifier = remainingKeyPath;
 
-                object[identifier] = newRecord.key;
+                // Bypass prototype when setting (See `bindings-inject-values-bypass.any.js`)
+                // Equivalent to `object[identifier] = ...` without using `Object.prototype`
+                Object.defineProperty(object, identifier, {
+                    configurable: true,
+                    enumerable: true,
+                    writable: true,
+                    value: newRecord.key,
+                });
             }
         } else if (
             this.keyGenerator !== null &&

--- a/src/test/web-platform-tests/manifests/bindings-inject-keys-bypass.any.toml
+++ b/src/test/web-platform-tests/manifests/bindings-inject-keys-bypass.any.toml
@@ -1,3 +1,0 @@
-# Did not investigate in great detail.
-["Returning keys to script should bypass prototype setters"]
-expectation = "FAIL"

--- a/src/test/web-platform-tests/manifests/bindings-inject-values-bypass.any.toml
+++ b/src/test/web-platform-tests/manifests/bindings-inject-values-bypass.any.toml
@@ -1,3 +1,0 @@
-# Did not investigate in great detail.
-["Returning values to script should bypass prototype setters"]
-expectation = "FAIL"


### PR DESCRIPTION
This complicates the code in ways I find a bit distasteful, but it does get us 2 more passing tests. I guess the idea here is that the IndexedDB engine should never use `Object.prototype` when constructing keys/values.