### PR TITLE
Allow readonly transactions to run in parallel

### DIFF
--- a/src/test/web-platform-tests/manifests/transaction-scheduling-within-database.any.toml
+++ b/src/test/web-platform-tests/manifests/transaction-scheduling-within-database.any.toml
@@ -1,3 +1,0 @@
-# async timing test which we currently fail:
-# "Check that read-only transactions within a database can run in parallel"
-expectTimeout = true


### PR DESCRIPTION
Fixes `transaction-scheduling-within-database.any.js`. Adds a special case for readonly transactions, which don't block each other but could block (or be blocked by) non-readonly transactions such as readwrite or versionchange transactions.