### PR TITLE
Test `onblocked` when reopening after `deleteDatabase`

### DIFF
--- a/src/test/fakeIndexedDB/fakeIndexedDB.ts
+++ b/src/test/fakeIndexedDB/fakeIndexedDB.ts
@@ -711,7 +711,7 @@ describe("fakeIndexedDB Tests", () => {
     });
 
     describe("Events", () => {
-        it.only("blocked deleteDatabase should cause subsequent open requests to hang (issue #163)", async () => {
+        it("blocked deleteDatabase should cause subsequent open requests to hang (issue #163)", async () => {
             const dbName = `idx_test_${Math.random()}`;
             // Create a dangling open connection
             const db = await new Promise<FDBDatabase>((resolve, reject) => {


### PR DESCRIPTION
Adds a test to confirm the behavior described in #163. This test fails in v6.2.2 but passes in the latest `master`. I also confirmed that the test passes against Chrome's and Firefox's native IDB implementations.

The issue here is subtle: if you call `deleteDatabase` and it's blocked (i.e. fires `onblocked`), then subsequent requests to `open` _should_ hang, due to the [connection queue](https://w3c.github.io/IndexedDB/#connection-queue). The reason for the reported change in behavior in v6.2.3 was undoubtedly https://github.com/dumbmatter/fakeIndexedDB/pull/144 which added the connection queue behavior.

This scenario looks like it's already covered by the WPT test `open-request-queue.any.js`, but it doesn't hurt to have more explicit tests.