### PR TITLE
Optimize internal key comparisons and tree rebuild for speed and lower allocations

### DIFF
--- a/src/FDBCursor.ts
+++ b/src/FDBCursor.ts
@@ -1,6 +1,6 @@
 import FDBKeyRange from "./FDBKeyRange.js";
 import FDBObjectStore from "./FDBObjectStore.js";
-import cmp from "./lib/cmp.js";
+import cmp, { cmpKeys } from "./lib/cmp.js";
 import {
     DataError,
     InvalidAccessError,
@@ -46,7 +46,7 @@ const makeKeyRange = (
             continue;
         }
 
-        if (lower === undefined || cmp(lower, lowerTemp) === 1) {
+        if (lower === undefined || cmpKeys(lower, lowerTemp) === 1) {
             lower = lowerTemp;
         }
     }
@@ -55,7 +55,7 @@ const makeKeyRange = (
             continue;
         }
 
-        if (upper === undefined || cmp(upper, upperTemp) === -1) {
+        if (upper === undefined || cmpKeys(upper, upperTemp) === -1) {
             upper = upperTemp;
         }
     }
@@ -151,10 +151,10 @@ class FDBCursor {
             const range = makeKeyRange(this._range, [key, this._position], []);
             for (const record of records.values(range)) {
                 const cmpResultKey =
-                    key !== undefined ? cmp(record.key, key) : undefined;
+                    key !== undefined ? cmpKeys(record.key, key) : undefined;
                 const cmpResultPosition =
                     this._position !== undefined
-                        ? cmp(record.key, this._position)
+                        ? cmpKeys(record.key, this._position)
                         : undefined;
                 if (key !== undefined) {
                     if (cmpResultKey === -1) {
@@ -165,7 +165,10 @@ class FDBCursor {
                     if (cmpResultKey === -1) {
                         continue;
                     }
-                    const cmpResultPrimaryKey = cmp(record.value, primaryKey);
+                    const cmpResultPrimaryKey = cmpKeys(
+                        record.value,
+                        primaryKey,
+                    );
                     if (cmpResultKey === 0 && cmpResultPrimaryKey === -1) {
                         continue;
                     }
@@ -181,7 +184,7 @@ class FDBCursor {
                     }
                     if (
                         cmpResultPosition === 0 &&
-                        cmp(record.value, this._objectStorePosition) !== 1
+                        cmpKeys(record.value, this._objectStorePosition) !== 1
                     ) {
                         continue;
                     }
@@ -201,12 +204,12 @@ class FDBCursor {
             const range = makeKeyRange(this._range, [key, this._position], []);
             for (const record of records.values(range)) {
                 if (key !== undefined) {
-                    if (cmp(record.key, key) === -1) {
+                    if (cmpKeys(record.key, key) === -1) {
                         continue;
                     }
                 }
                 if (this._position !== undefined) {
-                    if (cmp(record.key, this._position) !== 1) {
+                    if (cmpKeys(record.key, this._position) !== 1) {
                         continue;
                     }
                 }
@@ -222,10 +225,10 @@ class FDBCursor {
             const range = makeKeyRange(this._range, [], [key, this._position]);
             for (const record of records.values(range, "prev")) {
                 const cmpResultKey =
-                    key !== undefined ? cmp(record.key, key) : undefined;
+                    key !== undefined ? cmpKeys(record.key, key) : undefined;
                 const cmpResultPosition =
                     this._position !== undefined
-                        ? cmp(record.key, this._position)
+                        ? cmpKeys(record.key, this._position)
                         : undefined;
                 if (key !== undefined) {
                     if (cmpResultKey === 1) {
@@ -236,7 +239,10 @@ class FDBCursor {
                     if (cmpResultKey === 1) {
                         continue;
                     }
-                    const cmpResultPrimaryKey = cmp(record.value, primaryKey);
+                    const cmpResultPrimaryKey = cmpKeys(
+                        record.value,
+                        primaryKey,
+                    );
                     if (cmpResultKey === 0 && cmpResultPrimaryKey === 1) {
                         continue;
                     }
@@ -252,7 +258,7 @@ class FDBCursor {
                     }
                     if (
                         cmpResultPosition === 0 &&
-                        cmp(record.value, this._objectStorePosition) !== -1
+                        cmpKeys(record.value, this._objectStorePosition) !== -1
                     ) {
                         continue;
                     }
@@ -270,12 +276,12 @@ class FDBCursor {
             const range = makeKeyRange(this._range, [], [key, this._position]);
             for (const record of records.values(range, "prev")) {
                 if (key !== undefined) {
-                    if (cmp(record.key, key) === 1) {
+                    if (cmpKeys(record.key, key) === 1) {
                         continue;
                     }
                 }
                 if (this._position !== undefined) {
-                    if (cmp(record.key, this._position) !== -1) {
+                    if (cmpKeys(record.key, this._position) !== -1) {
                         continue;
                     }
                 }
@@ -490,7 +496,7 @@ class FDBCursor {
         if (key !== undefined) {
             key = valueToKey(key);
 
-            const cmpResult = cmp(key, this._position);
+            const cmpResult = cmpKeys(key, this._position);
 
             if (
                 (cmpResult <= 0 &&
@@ -552,14 +558,15 @@ class FDBCursor {
         }
 
         key = valueToKey(key);
-        const cmpResult = cmp(key, this._position);
+        const cmpResult = cmpKeys(key, this._position);
         if (
             (cmpResult === -1 && this.direction === "next") ||
             (cmpResult === 1 && this.direction === "prev")
         ) {
             throw new DataError();
         }
-        const cmpResult2 = cmp(primaryKey, this._objectStorePosition);
+        primaryKey = valueToKey(primaryKey);
+        const cmpResult2 = cmpKeys(primaryKey, this._objectStorePosition);
         if (cmpResult === 0) {
             if (
                 (cmpResult2 <= 0 && this.direction === "next") ||

--- a/src/FDBKeyRange.ts
+++ b/src/FDBKeyRange.ts
@@ -1,4 +1,4 @@
-import cmp from "./lib/cmp.js";
+import { cmpKeys } from "./lib/cmp.js";
 import { DataError } from "./lib/errors.js";
 import valueToKey from "./lib/valueToKey.js";
 import type { Key } from "./lib/types.js";
@@ -39,13 +39,13 @@ class FDBKeyRange {
             throw new TypeError();
         }
 
-        const cmpResult = cmp(lower, upper);
+        lower = valueToKey(lower);
+        upper = valueToKey(upper);
+        const cmpResult = cmpKeys(lower, upper);
         if (cmpResult === 1 || (cmpResult === 0 && (lowerOpen || upperOpen))) {
             throw new DataError();
         }
 
-        lower = valueToKey(lower);
-        upper = valueToKey(upper);
         return new FDBKeyRange(lower, upper, lowerOpen, upperOpen);
     }
 
@@ -74,14 +74,14 @@ class FDBKeyRange {
         key = valueToKey(key);
 
         if (this.lower !== undefined) {
-            const cmpResult = cmp(this.lower, key);
+            const cmpResult = cmpKeys(this.lower, key);
 
             if (cmpResult === 1 || (cmpResult === 0 && this.lowerOpen)) {
                 return false;
             }
         }
         if (this.upper !== undefined) {
-            const cmpResult = cmp(this.upper, key);
+            const cmpResult = cmpKeys(this.upper, key);
 
             if (cmpResult === -1 || (cmpResult === 0 && this.upperOpen)) {
                 return false;

--- a/src/lib/RecordStore.ts
+++ b/src/lib/RecordStore.ts
@@ -1,5 +1,5 @@
 import FDBKeyRange from "../FDBKeyRange.js";
-import cmp from "./cmp.js";
+import { cmpKeys } from "./cmp.js";
 import BinarySearchTree from "./binarySearchTree.js";
 import type { FDBCursorDirection, Key, Record } from "./types.js";
 
@@ -91,7 +91,10 @@ class RecordStore {
                             while (
                                 !current.done &&
                                 previousValue !== undefined &&
-                                cmp(previousValue.key, current.value.key) === 0
+                                cmpKeys(
+                                    previousValue.key,
+                                    current.value.key,
+                                ) === 0
                             ) {
                                 current = next();
                             }
@@ -110,7 +113,8 @@ class RecordStore {
                     next: (): IteratorResult<Record> => {
                         while (
                             !nextResult.done &&
-                            cmp(current.value.key, nextResult.value.key) === 0
+                            cmpKeys(current.value.key, nextResult.value.key) ===
+                                0
                         ) {
                             // note we return the _lowest_ possible value, hence set the current
                             current = nextResult;

--- a/src/lib/binarySearchTree.ts
+++ b/src/lib/binarySearchTree.ts
@@ -358,7 +358,7 @@ export default class BinarySearchTree {
         if (length <= 0) {
             return undefined;
         }
-        const mid = startIndex + (length >>> 1); // like Math.floor((start + end) / 2) but fast
+        const mid = startIndex + (length >>> 1); // the >>> is like Math.floor(length / 2) but fast
 
         const node: Node = {
             record: records[mid],

--- a/src/lib/binarySearchTree.ts
+++ b/src/lib/binarySearchTree.ts
@@ -1,5 +1,5 @@
 import FDBKeyRange from "../FDBKeyRange.js";
-import cmp from "./cmp.js";
+import { cmpKeys } from "./cmp.js";
 import { ConstraintError } from "./errors.js";
 import type { Record } from "./types.js";
 
@@ -68,13 +68,13 @@ export default class BinarySearchTree {
     }
 
     private _compare(a: Record, b: Record): number {
-        const keyComparison = cmp(a.key, b.key);
+        const keyComparison = cmpKeys(a.key, b.key);
         if (keyComparison !== 0) {
             return keyComparison;
         }
         // if keys are unique, then we can (and must) avoid comparing the values, since they may be non-comparable
         // (e.g. in the case of an ObjectStore, they are record objects)
-        return this._keysAreUnique ? 0 : cmp(a.value, b.value);
+        return this._keysAreUnique ? 0 : cmpKeys(a.value, b.value);
     }
 
     private _getByComparator(
@@ -229,8 +229,8 @@ export default class BinarySearchTree {
             record: { key },
         } = node;
 
-        const lowerComparison = lower === undefined ? -1 : cmp(lower, key);
-        const upperComparison = upper === undefined ? 1 : cmp(upper, key);
+        const lowerComparison = lower === undefined ? -1 : cmpKeys(lower, key);
+        const upperComparison = upper === undefined ? 1 : cmpKeys(upper, key);
 
         // if keys are non-unique then we need to go left/right even for equality
         // else we can just do LT/GT rather than LTE/GTE as a slight optimization

--- a/src/lib/binarySearchTree.ts
+++ b/src/lib/binarySearchTree.ts
@@ -351,12 +351,14 @@ export default class BinarySearchTree {
         records: Record[],
         parent: Node | undefined,
         red: boolean,
+        startIndex: number = 0,
+        endIndex: number = records.length,
     ): Node | undefined {
-        const { length } = records;
-        if (!length) {
+        const length = endIndex - startIndex;
+        if (length <= 0) {
             return undefined;
         }
-        const mid = length >>> 1; // like Math.floor(records.length / 2) but fast
+        const mid = startIndex + (length >>> 1); // like Math.floor((start + end) / 2) but fast
 
         const node: Node = {
             record: records[mid],
@@ -367,8 +369,8 @@ export default class BinarySearchTree {
             red,
         };
 
-        const left = this._rebuild(records.slice(0, mid), node, !red);
-        const right = this._rebuild(records.slice(mid + 1), node, !red);
+        const left = this._rebuild(records, node, !red, startIndex, mid);
+        const right = this._rebuild(records, node, !red, mid + 1, endIndex);
 
         node.left = left;
         node.right = right;

--- a/src/lib/cmp.ts
+++ b/src/lib/cmp.ts
@@ -21,15 +21,7 @@ const getType = (x: any) => {
     throw new DataError();
 };
 
-// https://w3c.github.io/IndexedDB/#compare-two-keys
-const cmp = (first: any, second: any): -1 | 0 | 1 => {
-    if (second === undefined) {
-        throw new TypeError();
-    }
-
-    first = valueToKey(first);
-    second = valueToKey(second);
-
+const cmpKeys = (first: any, second: any): -1 | 0 | 1 => {
     const t1 = getType(first);
     const t2 = getType(second);
 
@@ -53,14 +45,31 @@ const cmp = (first: any, second: any): -1 | 0 | 1 => {
     }
 
     if (t1 === "Binary") {
-        first = new Uint8Array(first);
-        second = new Uint8Array(second);
+        const firstBytes = new Uint8Array(first);
+        const secondBytes = new Uint8Array(second);
+        const length = Math.min(firstBytes.length, secondBytes.length);
+        for (let i = 0; i < length; i++) {
+            if (firstBytes[i] > secondBytes[i]) {
+                return 1;
+            }
+            if (firstBytes[i] < secondBytes[i]) {
+                return -1;
+            }
+        }
+
+        if (firstBytes.length > secondBytes.length) {
+            return 1;
+        }
+        if (firstBytes.length < secondBytes.length) {
+            return -1;
+        }
+        return 0;
     }
 
-    if (t1 === "Array" || t1 === "Binary") {
+    if (t1 === "Array") {
         const length = Math.min(first.length, second.length);
         for (let i = 0; i < length; i++) {
-            const result = cmp(first[i], second[i]);
+            const result = cmpKeys(first[i], second[i]);
 
             if (result !== 0) {
                 return result;
@@ -87,6 +96,15 @@ const cmp = (first: any, second: any): -1 | 0 | 1 => {
     }
 
     return first > second ? 1 : -1;
+};
+
+// https://w3c.github.io/IndexedDB/#compare-two-keys
+const cmp = (first: any, second: any): -1 | 0 | 1 => {
+    if (second === undefined) {
+        throw new TypeError();
+    }
+
+    return cmpKeys(valueToKey(first), valueToKey(second));
 };
 
 export default cmp;

--- a/src/lib/cmp.ts
+++ b/src/lib/cmp.ts
@@ -21,7 +21,7 @@ const getType = (x: any) => {
     throw new DataError();
 };
 
-const cmpKeys = (first: any, second: any): -1 | 0 | 1 => {
+export const cmpKeys = (first: any, second: any): -1 | 0 | 1 => {
     const t1 = getType(first);
     const t2 = getType(second);
 

--- a/src/lib/cmp.ts
+++ b/src/lib/cmp.ts
@@ -21,6 +21,14 @@ const getType = (x: any) => {
     throw new DataError();
 };
 
+/**
+ * Compare two already-normalized IndexedDB keys (i.e. keys that have already
+ * been run through `valueToKey`). Use this on internal/hot paths where keys
+ * are known to be valid to avoid redundant `valueToKey` conversions.
+ *
+ * For comparing raw/untrusted input, use the default-exported `cmp` instead —
+ * it validates and normalizes both arguments before comparing.
+ */
 export const cmpKeys = (first: any, second: any): -1 | 0 | 1 => {
     const t1 = getType(first);
     const t2 = getType(second);

--- a/src/lib/cmp.ts
+++ b/src/lib/cmp.ts
@@ -52,10 +52,13 @@ export const cmpKeys = (first: any, second: any): -1 | 0 | 1 => {
         return -1;
     }
 
+    // This block is effectively the same as the array comparison, but we avoid expensive `cmpKey` calls
     if (t1 === "Binary") {
         const firstBytes = new Uint8Array(first);
         const secondBytes = new Uint8Array(second);
-        const length = Math.min(firstBytes.length, secondBytes.length);
+        const firstLen = firstBytes.length;
+        const secondLen = secondBytes.length;
+        const length = Math.min(firstLen, secondLen);
         for (let i = 0; i < length; i++) {
             if (firstBytes[i] > secondBytes[i]) {
                 return 1;
@@ -65,10 +68,10 @@ export const cmpKeys = (first: any, second: any): -1 | 0 | 1 => {
             }
         }
 
-        if (firstBytes.length > secondBytes.length) {
+        if (firstLen > secondLen) {
             return 1;
         }
-        if (firstBytes.length < secondBytes.length) {
+        if (firstLen < secondLen) {
             return -1;
         }
         return 0;


### PR DESCRIPTION
## Summary
This PR improves hot-path key comparison performance and reduces allocations by:

- splitting `cmp` into public `cmp` (normalizes input via `valueToKey`) and internal `cmpKeys` (for already-normalized keys)
- replacing repeated internal `cmp(...)` calls with `cmpKeys(...)` in `FDBCursor`, `FDBKeyRange`, `RecordStore`, and `BinarySearchTree`
- optimizing binary key comparison path in `cmp`
- optimizing `BinarySearchTree._rebuild` to avoid recursive `slice()` allocations (index-range recursion)

## Benchmark comparison (mitata, Node 22.18.0, Intel i5-12450H)

| Scenario | Baseline | Optimized | Throughput gain | Allocation/heap effect |
|---|---:|---:|---:|---:|
| Known binary key comparisons (`cmp` vs `cmpKeys`) | 1.03-1.12 ms/iter | 0.10-0.11 ms/iter | **9.38x-9.87x faster** | **~1.96x lower** avg heap sample |
| `FDBKeyRange.includes` on binary keys | 2.40-2.61 ms/iter | 0.55-0.66 ms/iter | **3.98x-4.46x faster** | **~1.74x lower** avg heap sample |
| Nested array key comparisons | 146.9-181.3 ms/iter | 38.7-42.3 ms/iter | **3.79x-4.28x faster** | N/A |
| BST rebuild/compaction | 1.12-1.32 ms/iter | 0.44-0.53 ms/iter | **2.35x-2.63x faster** | materially lower temporary allocations (slice removal) |

> Heap figures come from mitata `stats.heap.avg` where available.

## Validation

- ✅ `pnpm test`
